### PR TITLE
Fix 'Lenght' spelling to 'Length'.

### DIFF
--- a/WPFHexaEditor/HexaEditor.xaml
+++ b/WPFHexaEditor/HexaEditor.xaml
@@ -269,7 +269,7 @@
                     <StackPanel Orientation="Horizontal">
                         <Label
                             Padding="5,5,0,5"
-                            Content="{x:Static p:Resources.LenghtString}"
+                            Content="{x:Static p:Resources.LengthString}"
                             FontWeight="Bold" />
                         <Label x:Name="FileLengthKbLabel" ContentStringFormat="N0" />
                     </StackPanel>

--- a/WPFHexaEditor/Properties/Resources.Designer.cs
+++ b/WPFHexaEditor/Properties/Resources.Designer.cs
@@ -553,11 +553,11 @@ namespace WpfHexaEditor.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Lenght.
+        ///   Looks up a localized string similar to Length.
         /// </summary>
-        public static string LenghtString {
+        public static string LengthString {
             get {
-                return ResourceManager.GetString("LenghtString", resourceCulture);
+                return ResourceManager.GetString("LengthString", resourceCulture);
             }
         }
         

--- a/WPFHexaEditor/Properties/Resources.fr-CA.resx
+++ b/WPFHexaEditor/Properties/Resources.fr-CA.resx
@@ -192,7 +192,7 @@
   <data name="KBTagString" xml:space="preserve">
     <value>Ko</value>
   </data>
-  <data name="LenghtString" xml:space="preserve">
+  <data name="LengthString" xml:space="preserve">
     <value>Taille</value>
   </data>
   <data name="LineStatusBarTagString" xml:space="preserve">

--- a/WPFHexaEditor/Properties/Resources.pl-PL.resx
+++ b/WPFHexaEditor/Properties/Resources.pl-PL.resx
@@ -235,7 +235,7 @@
   <data name="KBTagString" xml:space="preserve">
     <value>Kb</value>
   </data>
-  <data name="LenghtString" xml:space="preserve">
+  <data name="LengthString" xml:space="preserve">
     <value>Długość</value>
   </data>
   <data name="LineStatusBarTagString" xml:space="preserve">

--- a/WPFHexaEditor/Properties/Resources.pt-BR.resx
+++ b/WPFHexaEditor/Properties/Resources.pt-BR.resx
@@ -235,7 +235,7 @@
   <data name="KBTagString" xml:space="preserve">
     <value>Kb</value>
   </data>
-  <data name="LenghtString" xml:space="preserve">
+  <data name="LengthString" xml:space="preserve">
     <value>comprimento</value>
   </data>
   <data name="LineStatusBarTagString" xml:space="preserve">

--- a/WPFHexaEditor/Properties/Resources.resx
+++ b/WPFHexaEditor/Properties/Resources.resx
@@ -235,8 +235,8 @@
   <data name="KBTagString" xml:space="preserve">
     <value>Kb</value>
   </data>
-  <data name="LenghtString" xml:space="preserve">
-    <value>Lenght</value>
+  <data name="LengthString" xml:space="preserve">
+    <value>Length</value>
   </data>
   <data name="LineStatusBarTagString" xml:space="preserve">
     <value>Ln</value>

--- a/WPFHexaEditor/Properties/Resources.ru-RU.resx
+++ b/WPFHexaEditor/Properties/Resources.ru-RU.resx
@@ -228,7 +228,7 @@
   <data name="KBTagString" xml:space="preserve">
     <value>Kb</value>
   </data>
-  <data name="LenghtString" xml:space="preserve">
+  <data name="LengthString" xml:space="preserve">
     <value>Длинна</value>
   </data>
   <data name="LineStatusBarTagString" xml:space="preserve">

--- a/WPFHexaEditor/Properties/Resources.zh-CN.resx
+++ b/WPFHexaEditor/Properties/Resources.zh-CN.resx
@@ -228,7 +228,7 @@
   <data name="KBTagString" xml:space="preserve">
     <value>KB</value>
   </data>
-  <data name="LenghtString" xml:space="preserve">
+  <data name="LengthString" xml:space="preserve">
     <value>字节长度</value>
   </data>
   <data name="LineStatusBarTagString" xml:space="preserve">


### PR DESCRIPTION
'Length' was spelled 'Lenght' throughout the project, incorrectly.

### Proof of spelling from Google:
https://prnt.sc/ij4xfo