### PR TITLE
Fixed issue: Can not open with write permissions previously opened file

### DIFF
--- a/WpfHexaEditor.Shared/Core/Bytes/ByteProvider.cs
+++ b/WpfHexaEditor.Shared/Core/Bytes/ByteProvider.cs
@@ -447,6 +447,7 @@ namespace WpfHexaEditor.Core.Bytes
 
                 var refreshByteProvider = false;
                 if (File.Exists(_newfilename)) {
+                    _stream?.Close();
                     _stream = File.Open(_newfilename, FileMode.Open, FileAccess.ReadWrite, FileShare.Read);
                     _stream.SetLength(newStream.Length);
                     refreshByteProvider = true;


### PR DESCRIPTION
**Steps to reproduce:**
1. Open a file
2. Save the file to another one
3. Open the file from step 1 again

**Expected result:**
 - The file is opened with write permissions

**Actual result:**
 - The file is locked and can not be opened with write permissions