### PR TITLE
ByteProviderTest. ByteProvider should be disposed

### DIFF
--- a/WpfHexEditor.UnitTest/ByteProviderTest.cs
+++ b/WpfHexEditor.UnitTest/ByteProviderTest.cs
@@ -22,6 +22,8 @@ namespace HexEditUnitTest
             var byteCount = bp.GetByteCount().Sum();
             watch.Stop();
 
+            bp.Dispose();
+
             Console.WriteLine($@"duration {watch.Elapsed}");
             Console.WriteLine($@"File length {length}");
 


### PR DESCRIPTION
Looks like you forgot to call Dispose method in ByteProviderTest method.