### PR TITLE
Fixed null reference in rare cases when Scrollbar.Track is null

### DIFF
--- a/Sources/WPFHexaEditor/HexEditor.xaml.cs
+++ b/Sources/WPFHexaEditor/HexEditor.xaml.cs
@@ -3672,7 +3672,7 @@ namespace WpfHexaEditor
 
             #region Set position in scrollbar
 
-            var topPosition =
+            var topPosition = (VerticalScrollBar.Track == null) ? double.NaN :
                 (GetLineNumber(bookMark.BytePositionInStream) * VerticalScrollBar.Track.TickHeight(MaxLine) - 1).Round(1);
 
             if (double.IsNaN(topPosition))


### PR DESCRIPTION
In my application I had the scenario that the VerticalScrollbar.Track property was null and for some reason at the changed line this caused an NullReferenceException. This way it works without throwing an exception.