### PR TITLE
Fixed NullReferenceException when setting Stream property to null

### DIFF
--- a/Sources/WPFHexaEditor/HexEditor.xaml.cs
+++ b/Sources/WPFHexaEditor/HexEditor.xaml.cs
@@ -1996,7 +1996,8 @@ namespace WpfHexaEditor
             if (!(d is HexEditor ctrl)) return;
 
             ctrl.CloseProvider();
-            ctrl.OpenStream((Stream)e.NewValue);
+            if (e.NewValue != null)
+                ctrl.OpenStream((Stream)e.NewValue);
         }
 
         /// <summary>


### PR DESCRIPTION
Expected behavior for MVVM would be that setting the stream to null results in resetting the control to a blank state. Currently it throws an NullReferenceException due to a missing null-check in the property changed event handler