### PR TITLE
Add support for changing the width of string bytes

### DIFF
--- a/Sources/WPFHexaEditor/Core/Caret.cs
+++ b/Sources/WPFHexaEditor/Core/Caret.cs
@@ -86,6 +86,7 @@ namespace WpfHexaEditor.Core
             set
             {
                 if (_caretHeight == value) return;
+                if (value < 0) value = 0;
 
                 _caretHeight = value;
 
@@ -104,6 +105,7 @@ namespace WpfHexaEditor.Core
             set
             {
                 if (_caretWidth == value) return;
+                if (value < 0) value = 0;
 
                 _caretWidth = value;
 

--- a/Sources/WPFHexaEditor/HexEditor.xaml.cs
+++ b/Sources/WPFHexaEditor/HexEditor.xaml.cs
@@ -2561,6 +2561,51 @@ namespace WpfHexaEditor
 
         #endregion
 
+        #region ByteWidth property/methods
+
+        /// <summary>
+        /// Get or set the width of string bytes
+        /// </summary>
+        public double StringByteWidth
+        {
+            get => (double)GetValue(StringByteWidthProperty);
+            set => SetValue(StringByteWidthProperty, value);
+        }
+
+        public static readonly DependencyProperty StringByteWidthProperty =
+            DependencyProperty.Register("StringByteWidth", typeof(double), typeof(HexEditor),
+                new FrameworkPropertyMetadata(12d, StringByteWidth_PropertyChanged,
+                    StringByteWidth_CoerceValue));
+
+        private static object StringByteWidth_CoerceValue(DependencyObject d, object baseValue) =>
+            (double)baseValue < 1 ? 1 : ((double)baseValue > 64 ? 64 : baseValue);
+
+        private static void StringByteWidth_PropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            if (d is not HexEditor ctrl || e.NewValue == e.OldValue) return;
+
+            ctrl.With(c =>
+            {
+                //Get previous state
+                var firstPos = c.FirstVisibleBytePosition;
+                var startPos = c.SelectionStart;
+                var stopPos = c.SelectionStop;
+
+                //refresh
+                c.UpdateScrollBar();
+                c.BuildDataLines(c.MaxVisibleLine, true);
+                c.RefreshView(true);
+                c.UpdateHeader(true);
+
+                //Set previous state
+                c.SetPosition(firstPos);
+                c.SelectionStart = startPos;
+                c.SelectionStop = stopPos;
+            });
+        }
+
+        #endregion
+
         #region vertical scrollbar property/methods
 
         /// <summary>
@@ -2711,7 +2756,7 @@ namespace WpfHexaEditor
                                                        ByteSpacerPositioning == ByteSpacerPosition.StringBytePanel))
                         AddByteSpacer(dataLineStack, i);
                     
-                    new StringByte(this, BarChartPanelVisibility == Visibility.Visible).With(c =>
+                    new StringByte(this, BarChartPanelVisibility == Visibility.Visible, StringByteWidth).With(c =>
                     {
                         c.Clear();
                         dataLineStack.Children.Add(c);

--- a/Sources/WPFHexaEditor/StringByte.cs
+++ b/Sources/WPFHexaEditor/StringByte.cs
@@ -22,12 +22,16 @@ namespace WpfHexaEditor
 
         private bool _tblShowMte = true;
         private readonly bool _barchart = false;
+        private double _width = 12d;
 
         #endregion Global variable
 
         #region Contructor
 
-        public StringByte(HexEditor parent, bool barChart) : base(parent) => _barchart = barChart;
+        public StringByte(HexEditor parent, bool barChart, double desiredWidth) : base(parent) {
+            _barchart = barChart;
+            _width = desiredWidth;
+        }
 
         #endregion Contructor
 
@@ -178,7 +182,7 @@ namespace WpfHexaEditor
         {
             if (_barchart)
             {
-                Width = 12;
+                Width = _width;
                 Margin = new Thickness(2);
 
                 #region Draw control
@@ -208,8 +212,8 @@ namespace WpfHexaEditor
 
                 Width = TypeOfCharacterTable switch
                 {
-                    CharacterTableType.Ascii => 12,
-                    CharacterTableType.TblFile => TextFormatted?.Width > 12 ? TextFormatted.Width : 12,
+                    CharacterTableType.Ascii => _width,
+                    CharacterTableType.TblFile => TextFormatted?.Width > _width ? TextFormatted.Width : _width,
                     _ => throw new NotImplementedException()
                 };
                 #endregion


### PR DESCRIPTION
I personally think the spacing between the string bytes is a bit much but since that's pretty subjective, I added a way to change it! 

Let me know what you think

Before | After (StringByteWidth set to 8)
------------ | -------------
![image](https://user-images.githubusercontent.com/24460210/103469706-f5037680-4d1c-11eb-81ae-dd3044f61d6f.png) | ![image](https://user-images.githubusercontent.com/24460210/103469707-faf95780-4d1c-11eb-8ffe-22de9576a86d.png)
