### PR TITLE
Fixed improper AssemblyVersion

### DIFF
--- a/Sources/WPFHexaEditor/WpfHexEditorCore.csproj
+++ b/Sources/WPFHexaEditor/WpfHexEditorCore.csproj
@@ -17,7 +17,7 @@
     <PackageIconUrl />
     <Product>WpfHexaEditor</Product>
     <Copyright>Apache 2.0</Copyright>
-    <AssemblyVersion>2.1.6</AssemblyVersion>
+    <AssemblyVersion>2.1.6.0</AssemblyVersion>
     <FileVersion>2.1.6</FileVersion>
     <Version>2.1.6</Version>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>


### PR DESCRIPTION
Fixed issue #97. It also fixes another related error, where the WinForms Designer will show an error and refuse to load, if there is an existing HexEditor/HexBox like in the Sample WinForm project. Image of error shown below: 
![devenv_3tGWxAPAed](https://user-images.githubusercontent.com/31831208/117475596-2783e100-af54-11eb-9e22-8f8e69219059.png)
