### PR TITLE
Fixed ChangesSubmited closed stream & Control_ByteModified default ByteEventArgs

### DIFF
--- a/Sources/WPFHexaEditor/Core/Bytes/ByteProvider.cs
+++ b/Sources/WPFHexaEditor/Core/Bytes/ByteProvider.cs
@@ -403,6 +403,10 @@ namespace WpfHexaEditor.Core.Bytes
 
                             _stream.Position = bm.Key;
                             _stream.WriteByte(bm.Value.Byte.Value);
+
+                            //Clear the edited bytes background colour.
+                            bm.Value.Action = ByteAction.Nothing;
+                            _byteModifiedDictionary.Remove(bm);
                         }
 
                     #endregion

--- a/Sources/WPFHexaEditor/HexEditor.xaml.cs
+++ b/Sources/WPFHexaEditor/HexEditor.xaml.cs
@@ -1023,7 +1023,11 @@ namespace WpfHexaEditor
             if (_provider.ReadOnlyMode) return;
 
             if (sender is IByteControl ctrl)
+            {
                 ModifyByte(ctrl.Byte.Byte[e.Index], ctrl.BytePositionInStream + e.Index);
+
+                e.BytePositionInStream = ctrl.BytePositionInStream;
+            }
 
             BytesModified?.Invoke(this, e);
         }
@@ -2092,13 +2096,7 @@ namespace WpfHexaEditor
             //Refresh stream
             if (!CheckIsOpen(_provider)) return;
 
-            var stream = new MemoryStream();
-
-            _provider.Position = 0;
-            _provider.Stream.CopyTo(stream);
-
-            CloseProvider();
-            OpenStream(stream);
+            RefreshView(true);
 
             ChangesSubmited?.Invoke(this, new EventArgs());
         }

--- a/Sources/WPFHexaEditor/HexEditor.xaml.cs
+++ b/Sources/WPFHexaEditor/HexEditor.xaml.cs
@@ -2092,14 +2092,13 @@ namespace WpfHexaEditor
             //Refresh stream
             if (!CheckIsOpen(_provider)) return;
 
-            using (var stream = new MemoryStream())
-            {
-                _provider.Position = 0;
-                _provider.Stream.CopyTo(stream);
+            var stream = new MemoryStream();
 
-                CloseProvider();
-                OpenStream(stream);
-            }
+            _provider.Position = 0;
+            _provider.Stream.CopyTo(stream);
+
+            CloseProvider();
+            OpenStream(stream);
 
             ChangesSubmited?.Invoke(this, new EventArgs());
         }

--- a/Sources/WPFHexaEditor/WpfHexEditorCore.csproj
+++ b/Sources/WPFHexaEditor/WpfHexEditorCore.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
-    <TargetFrameworks>net47;net48;net50-windows</TargetFrameworks>
+    <TargetFrameworks>net48;net50-windows</TargetFrameworks>
+	  <!--<TargetFrameworks>net47;net48;net50-windows</TargetFrameworks>-->
     <UseWPF>true</UseWPF>
     <RootNamespace>WpfHexaEditor</RootNamespace>
     <AssemblyName>WPFHexaEditor</AssemblyName>

--- a/Sources/WPFHexaEditor/WpfHexEditorCore.csproj
+++ b/Sources/WPFHexaEditor/WpfHexEditorCore.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
-    <TargetFrameworks>net48;net50-windows</TargetFrameworks>
-	  <!--<TargetFrameworks>net47;net48;net50-windows</TargetFrameworks>-->
+	  <TargetFrameworks>net47;net48;net50-windows</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <RootNamespace>WpfHexaEditor</RootNamespace>
     <AssemblyName>WPFHexaEditor</AssemblyName>


### PR DESCRIPTION
When accessing the stream using ChangesSubmited event the stream was closed, since the changes are "submitted" it would make sense that you can access the stream with the changes.

If you don't want to edit ByteProvider, this is an alternative solution.
```csharp
private void ProviderStream_ChangesSubmited(object sender, EventArgs e)
{
   //Refresh stream
   if (!CheckIsOpen(_provider)) return;

   var stream = new MemoryStream();

   _provider.Position = 0;
   _provider.Stream.CopyTo(stream);

   Stream = stream;

   ChangesSubmited?.Invoke(this, new EventArgs());
}
```

The event Control_ByteModified would return a default ByteEventArgs instead of updating BytePositionInStream.

This patch fixes both of these issues.