### PR TITLE
Add support for a base offset that is added to all displayed offsets

### DIFF
--- a/Sources/WPFHexaEditor/HexEditor.xaml.cs
+++ b/Sources/WPFHexaEditor/HexEditor.xaml.cs
@@ -652,6 +652,20 @@ namespace WpfHexaEditor
             DependencyProperty.Register(nameof(OffSetPanelFixedWidthVisual), typeof(OffSetPanelFixedWidth), typeof(HexEditor),
                 new FrameworkPropertyMetadata(OffSetPanelFixedWidth.Dynamic, OffSetPanelVisual_PropertyChanged));
 
+
+        /// <summary>
+        /// Get or set the offset base, which is added to all offsets before they are displayed
+        /// </summary>
+        public long OffsetBase
+        {
+            get => (long)GetValue(OffsetBaseProperty);
+            set => SetValue(OffsetBaseProperty, value);
+        }
+
+        public static readonly DependencyProperty OffsetBaseProperty =
+            DependencyProperty.Register(nameof(OffsetBase), typeof(long), typeof(HexEditor),
+                new FrameworkPropertyMetadata(0L, OffSetPanelVisual_PropertyChanged));
+
         /// <summary>
         /// Get or set of the tooltip are shown over the IByteControl
         /// </summary>
@@ -3263,6 +3277,8 @@ namespace WpfHexaEditor
 
                         actualPosition = firstByteInLine;
                     }
+
+                    actualPosition += OffsetBase;
 
                     //update the visual
                     switch (OffSetStringVisual)


### PR DESCRIPTION
I'm using this project for a memory editor, which means I pass a `MemoryStream` which comes from a virtual page of memory. For example, a memory page might be loaded into address 0x00500000 and have 4096 (0x1000) bytes. I would want the first offset in the hex editor to say 0x00500000, and the last to be 0x00501000.

This pull request adds support for that, by adding a base offset to all offsets before the display strings are created.

Example using a long base address:
![image](https://user-images.githubusercontent.com/5906208/205606260-ae746a12-380e-4e6e-979e-5abfaa2c2f47.png)

Example dynamically changing OffsetBase property:
https://user-images.githubusercontent.com/5906208/205606514-af665c68-6f31-4f57-88fd-98e24a43f40b.mp4

