### PR TITLE
Fixed not been able to control ReadOnlyMode property using one-way data binding (#133)

### DIFF
--- a/Sources/WPFHexaEditor/HexEditor.xaml.cs
+++ b/Sources/WPFHexaEditor/HexEditor.xaml.cs
@@ -1018,7 +1018,7 @@ namespace WpfHexaEditor
         {
             if (!CheckIsOpen(_provider)) return;
 
-            ReadOnlyMode = _provider.IsLockedFile || _provider.ReadOnlyMode;
+            SetCurrentValue(ReadOnlyModeProperty, _provider.IsLockedFile || _provider.ReadOnlyMode);
 
             ReadOnlyChanged?.Invoke(sender, e);
         }
@@ -5072,8 +5072,9 @@ namespace WpfHexaEditor
             #endregion
 
             #region Set the readonly mode
-            ReadOnlyMode = bool.TryParse(doc.Element("WpfHexEditor").Attribute(nameof(ReadOnlyMode)).Value, out bool readOnlyMode)
-&& readOnlyMode;
+
+            SetCurrentValue(ReadOnlyModeProperty, bool.TryParse(doc.Element("WpfHexEditor").Attribute(nameof(ReadOnlyMode)).Value, out bool readOnlyMode) && readOnlyMode);
+
             #endregion
         }
 


### PR DESCRIPTION
This pull request fixes issue #133 that prevents ReadOnlyMode property from been controlled by one-way data binding.
There are however more issues with the same underlining problem that remain as they are.

The problem is that the editor is changing it's own its own dependency properties, which resets the value source configured by the user of the control.

Control should always use [SetCurrentValue](https://learn.microsoft.com/en-us/dotnet/api/system.windows.dependencyobject.setcurrentvalue?view=windowsdesktop-7.0) to set the value of **its own** dependency properties, since it changes the effective value of the property, but keeps existing triggers, data bindings, and styles.
