### PR TITLE
Fix compilation errors in C# 14

### DIFF
--- a/Sources/WPFHexaEditor/Core/Bytes/Byte_16bit.cs
+++ b/Sources/WPFHexaEditor/Core/Bytes/Byte_16bit.cs
@@ -40,10 +40,10 @@ namespace WpfHexaEditor.Core.Bytes
             var value = new byte[2];
             var sign_positive = true;
             var prefix = "";
-            var byteValue = (order == ByteOrderType.HiLo) ? Byte.ToArray().Reverse().ToArray() : Byte.ToArray();
-            var originValue = (order == ByteOrderType.HiLo) ? OriginByte.ToArray().Reverse().ToArray() : OriginByte.ToArray();
-            var ByteInt = BitConverter.ToUInt16(byteValue.Reverse().ToArray(), 0);
-            var OriginInt = BitConverter.ToUInt16(originValue.Reverse().ToArray(), 0);
+            var byteValue = (order == ByteOrderType.HiLo) ? Byte.AsEnumerable().Reverse().ToArray() : Byte.ToArray();
+            var originValue = (order == ByteOrderType.HiLo) ? OriginByte.AsEnumerable().Reverse().ToArray() : OriginByte.ToArray();
+            var ByteInt = BitConverter.ToUInt16(byteValue.AsEnumerable().Reverse().ToArray(), 0);
+            var OriginInt = BitConverter.ToUInt16(originValue.AsEnumerable().Reverse().ToArray(), 0);
 
             switch (state)
             {
@@ -90,7 +90,7 @@ namespace WpfHexaEditor.Core.Bytes
                         break;
                     case DataVisualType.Decimal:
                         text = (sign_positive ? "" : "-") + prefix +
-                            BitConverter.ToUInt16(value: value.Reverse().ToArray(), startIndex: 0).ToString("d5");
+                            BitConverter.ToUInt16(value: value.AsEnumerable().Reverse().ToArray(), startIndex: 0).ToString("d5");
                         break;
                     case DataVisualType.Binary:
                         text = (sign_positive ? "" : "-") + prefix +

--- a/Sources/WPFHexaEditor/Core/Bytes/Byte_32bit.cs
+++ b/Sources/WPFHexaEditor/Core/Bytes/Byte_32bit.cs
@@ -43,10 +43,10 @@ namespace WpfHexaEditor.Core.Bytes
             var prefix = "";
 
             var byteValue = (order == ByteOrderType.HiLo)
-                ? Byte.ToArray().Reverse().ToArray()
+                ? Byte.AsEnumerable().Reverse().ToArray()
                 : Byte.ToArray();
             var originValue = (order == ByteOrderType.HiLo)
-                ? OriginByte.ToArray().Reverse().ToArray()
+                ? OriginByte.AsEnumerable().Reverse().ToArray()
                 : OriginByte.ToArray();
             var ByteInt = BitConverter.ToUInt32(byteValue, 0);
             var OriginInt = BitConverter.ToUInt32(originValue, 0);
@@ -100,7 +100,7 @@ namespace WpfHexaEditor.Core.Bytes
                         break;
                     case DataVisualType.Decimal:
                         text = (sign_positive ? "" : "-") + prefix +
-                            BitConverter.ToUInt32(value.Reverse().ToArray(), 0).ToString("d10");
+                            BitConverter.ToUInt32(value.AsEnumerable().Reverse().ToArray(), 0).ToString("d10");
                         break;
                     case DataVisualType.Binary:
                         text = (sign_positive ? "" : "-") + prefix +


### PR DESCRIPTION
After updating Visual Studio to version 17.13.5, C# 14.0 became available. However, this introduced a compilation issue in the project. As noted in dotnet/runtime#107723, C# 14.0 introduces first-class support for spans. As a result, when calling `Reverse` on a byte[], the compiler now resolves it to the span-based method [```void MemoryExtensions.Reverse<T>(this Span<T>)```](https://learn.microsoft.com/en-us/dotnet/api/system.memoryextensions.reverse?view=net-8.0) rather than the LINQ version, [```IEnumerable<T> Enumerable.Reverse<T>(this IEnumerable<T>)```](https://learn.microsoft.com/en-us/dotnet/api/system.linq.enumerable.reverse?view=net-8.0). This change causes the project to fail to compile in the latest versions of Visual Studio, including 17.13.5 and 17.13.6.

This PR resolves the issue by first calling `AsEnumerable` to convert the array to an `IEnumerable`, ensuring that the correct version of `Reverse` is used. This should fix #140 .

Alternatively, for this project, another fix would be to lower the C# language version by modifying `<LangVersion>preview</LangVersion>` in WpfHexEditorCore.csproj to a version below C# 14.0. 
