### PR TITLE
fix: restore DocumentHost/SolutionManager/LspServers/BuildRun lost in PR #192 merge

### DIFF
--- a/Sources/Samples/WpfHexEditor.Sample.Terminal/StandaloneIDEHostContext.cs
+++ b/Sources/Samples/WpfHexEditor.Sample.Terminal/StandaloneIDEHostContext.cs
@@ -19,6 +19,7 @@
 
 using System.Windows;
 using WpfHexEditor.Core.Interfaces;
+using WpfHexEditor.Editor.Core.Documents;
 using WpfHexEditor.Events;
 using WpfHexEditor.SDK.Contracts;
 using WpfHexEditor.SDK.Contracts.Focus;
@@ -40,7 +41,10 @@ namespace WpfHexEditor.Sample.Terminal;
 /// </summary>
 internal sealed class StandaloneIDEHostContext : IIDEHostContext
 {
+    public IDocumentHostService     DocumentHost     { get; } = new NullDocumentHostService();
     public ISolutionExplorerService SolutionExplorer { get; } = new NullSolutionExplorerService();
+    public WpfHexEditor.Editor.Core.ISolutionManager? SolutionManager => null;
+    public WpfHexEditor.Editor.Core.LSP.ILspServerRegistry? LspServers => null;
     public IHexEditorService        HexEditor        { get; } = new NullHexEditorService();
     public ICodeEditorService       CodeEditor       { get; } = new NullCodeEditorService();
     public IOutputService           Output           { get; } = new NullOutputService();
@@ -60,6 +64,37 @@ internal sealed class StandaloneIDEHostContext : IIDEHostContext
 // ---------------------------------------------------------------------------
 // Service stubs
 // ---------------------------------------------------------------------------
+
+file sealed class NullDocumentHostService : IDocumentHostService
+{
+    public IDocumentManager Documents { get; } = new NullDocumentManager();
+
+    public void OpenDocument(string filePath, string? preferredEditorId = null) { }
+    public void ActivateAndNavigateTo(string filePath, int line, int column)    { }
+    public void SaveAll()                                                        { }
+
+    private sealed class NullDocumentManager : IDocumentManager
+    {
+        public IReadOnlyList<DocumentModel> OpenDocuments => [];
+        public DocumentModel?               ActiveDocument => null;
+
+        public DocumentModel Register(string contentId, string? filePath, string? editorId, string? projectItemId)
+            => new(contentId, filePath, projectItemId, editorId);
+        public void AttachEditor(string contentId, WpfHexEditor.Editor.Core.IDocumentEditor editor) { }
+        public void Unregister(string contentId) { }
+        public void SetActive(string contentId)  { }
+
+        public IReadOnlyList<DocumentModel> GetDirty() => [];
+
+#pragma warning disable 67
+        public event EventHandler<DocumentModel>?  DocumentRegistered;
+        public event EventHandler<DocumentModel>?  DocumentUnregistered;
+        public event EventHandler<DocumentModel?>? ActiveDocumentChanged;
+        public event EventHandler<DocumentModel>?  DocumentDirtyChanged;
+        public event EventHandler<DocumentModel>?  DocumentTitleChanged;
+#pragma warning restore 67
+    }
+}
 
 file sealed class NullSolutionExplorerService : ISolutionExplorerService
 {
@@ -106,6 +141,8 @@ file sealed class NullHexEditorService : IHexEditorService
     public void SetSelection(long start, long end)           { }
     public void ConnectParsedFieldsPanel(IParsedFieldsPanel panel)  { }
     public void DisconnectParsedFieldsPanel()                       { }
+    public void AddCustomBackgroundBlock(WpfHexEditor.Core.CustomBackgroundBlock block) { }
+    public void ClearCustomBackgroundBlockByTag(string tag)         { }
 
 #pragma warning disable 67
     public event EventHandler? ViewportScrolled;

--- a/Sources/WpfHexEditor.Options/OptionsPageRegistry.cs
+++ b/Sources/WpfHexEditor.Options/OptionsPageRegistry.cs
@@ -42,6 +42,10 @@ public static class OptionsPageRegistry
 
         // Plugin System
         new("Plugin System",      "General",          () => new PluginSystemOptionsPage(),    "⚙️"),
+
+        // Build & Run
+        new("Build & Run",        "General",          () => new BuildRunGeneralOptionsPage(), "🔨"),
+        new("Build & Run",        "Compiler",         () => new BuildCompilerOptionsPage(),   "🔨"),
     ];
 
     /// <summary>

--- a/Sources/WpfHexEditor.PluginHost/PluginScopedContext.cs
+++ b/Sources/WpfHexEditor.PluginHost/PluginScopedContext.cs
@@ -42,6 +42,12 @@ internal sealed class PluginScopedContext : IIDEHostContext
     public ISolutionExplorerService SolutionExplorer => _inner.SolutionExplorer;
 
     /// <inheritdoc />
+    public WpfHexEditor.Editor.Core.ISolutionManager? SolutionManager => _inner.SolutionManager;
+
+    /// <inheritdoc />
+    public WpfHexEditor.Editor.Core.LSP.ILspServerRegistry? LspServers => _inner.LspServers;
+
+    /// <inheritdoc />
     public ICodeEditorService CodeEditor => _inner.CodeEditor;
 
     /// <inheritdoc />
@@ -79,6 +85,9 @@ internal sealed class PluginScopedContext : IIDEHostContext
 
     /// <inheritdoc />
     public IExtensionRegistry ExtensionRegistry => _inner.ExtensionRegistry;
+
+    /// <inheritdoc />
+    public IDocumentHostService DocumentHost => _inner.DocumentHost;
 
     public PluginScopedContext(IIDEHostContext inner, TimedHexEditorService timedHexEditor)
     {

--- a/Sources/WpfHexEditor.SDK/Contracts/IIDEHostContext.cs
+++ b/Sources/WpfHexEditor.SDK/Contracts/IIDEHostContext.cs
@@ -4,6 +4,8 @@
 // Contributors: Claude Sonnet 4.6
 //////////////////////////////////////////////
 
+using WpfHexEditor.Editor.Core;
+using WpfHexEditor.Editor.Core.LSP;
 using WpfHexEditor.Events;
 using WpfHexEditor.SDK.Contracts.Services;
 
@@ -15,10 +17,26 @@ namespace WpfHexEditor.SDK.Contracts;
 /// </summary>
 public interface IIDEHostContext
 {
+    // -- Document Management --------------------------------------------------
+
+    /// <summary>
+    /// High-level document host service for opening, activating and navigating to
+    /// document tabs. Use this to open files from plugins or IDE panels (ErrorList, etc.)
+    /// without holding a direct reference to MainWindow.
+    /// </summary>
+    IDocumentHostService DocumentHost { get; }
+
     // -- IDE Services ---------------------------------------------------------
 
     /// <summary>Access to the Solution Explorer for file/project navigation.</summary>
     ISolutionExplorerService SolutionExplorer { get; }
+
+    /// <summary>
+    /// Access to the WH native project/solution manager.
+    /// Null when the host does not expose this service (e.g. sandboxed plugins).
+    /// Use to add generated files to an open WH project via <see cref="ISolutionManager.CreateItemAsync"/>.
+    /// </summary>
+    ISolutionManager? SolutionManager { get; }
 
     /// <summary>Access to the active HexEditor content and selection state.</summary>
     IHexEditorService HexEditor { get; }
@@ -96,4 +114,14 @@ public interface IIDEHostContext
     /// for a given extension point without knowing which plugins provided them.
     /// </summary>
     IExtensionRegistry ExtensionRegistry { get; }
+
+    // -- LSP (Language Server Protocol) ---------------------------------------
+
+    /// <summary>
+    /// Registry of configured LSP server executables keyed by language / extension.
+    /// Use <see cref="ILspServerRegistry.CreateClient"/> to obtain an
+    /// <see cref="ILspClient"/> for a specific file.
+    /// Null when the LSP.Client assembly is not loaded.
+    /// </summary>
+    ILspServerRegistry? LspServers { get; }
 }


### PR DESCRIPTION
## Summary

Restores 4 files where `--theirs` conflict resolution dropped feature-branch members:

- **`IIDEHostContext.cs`** — `DocumentHost`, `SolutionManager`, `LspServers` removed → **runtime crash** (`MissingMethodException` on plugin `InitializeAsync`)
- **`PluginScopedContext.cs`** — proxy not forwarding new interface members
- **`StandaloneIDEHostContext.cs`** — Terminal sample missing null implementations
- **`OptionsPageRegistry.cs`** — Build & Run options pages (General + Compiler) missing from IDE options dialog

## Root Cause

PR #192 resolved merge conflicts by taking master's version (`--theirs`) for these files. Master did not yet have the feature branch additions, so they were silently dropped. Build passed (0 errors) because the interface and all implementations were updated consistently — but in the wrong direction.

## Fix

Restored all 4 files to the feature branch version (commit `99ddfde7`). Build: 0 errors confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)