### PR TITLE
feat(editors+formats): FormatSchemaValidator, TextEditor viewport fix, 27 new whfmt formats

### DIFF
--- a/Sources/Core/WpfHexEditor.Core.Definitions/FormatDefinitions/Archives/ANDROID_BACKUP.whfmt
+++ b/Sources/Core/WpfHexEditor.Core.Definitions/FormatDefinitions/Archives/ANDROID_BACKUP.whfmt
@@ -1,0 +1,257 @@
+{
+  "diffMode": "binary",
+  "formatName": "Android Backup",
+  "version": "1.0",
+  "extensions": [".ab"],
+  "description": "Android Backup (.ab) files are produced by `adb backup` (Android Debug Bridge) and contain a full or partial device backup including app data, shared storage, and system settings. The format starts with an ASCII text header terminated by newlines, followed by a TAR archive that may be compressed (zlib deflate) and/or encrypted (AES-256 CBC). Header line 1: 'ANDROID BACKUP' (14 bytes + LF). Line 2: format version number ('1' through '5' + LF). Line 3: compression flag ('1'=compressed, '0'=uncompressed + LF). Line 4: encryption type ('none', 'AES-256' + LF). If AES-256: additional lines carry the PBKDF2 salt (hex), checksum salt (hex), iterations count, master key IV (hex), and master key blob (hex). After the text header, the payload is a standard POSIX TAR archive (optionally zlib-compressed, optionally AES-256 encrypted). Version history: v1=Android 4.0 ICS, v2=Android 4.1 JB (shared storage), v3=Android 4.2 (multi-user), v4=Android 4.4 KitKat, v5=Android 6.0 Marshmallow (full backup API).",
+  "category": "Archives",
+  "author": "WPFHexaEditor Team",
+  "preferredEditor": "hex-editor",
+  "references": {
+    "specifications": [
+      "Android BackupManagerService — AOSP source code",
+      "Android adb backup format — Android Open Source Project documentation"
+    ],
+    "WebLinks": [
+      "https://nelenkov.blogspot.com/2012/06/unpacking-android-backups.html",
+      "https://github.com/nelenkov/android-backup-extractor",
+      "https://developer.android.com/guide/topics/data/autobackup"
+    ]
+  },
+  "detection": {
+    "signatures": [
+      { "value": "414E44524F494420424143 4B55500A", "offset": 0, "label": "'ANDROID BACKUP\\n' — Android adb backup file header (15 bytes)", "weight": 1.0 },
+      { "value": "414E44524F49442042414 34B55500A", "offset": 0, "label": "'ANDROID BACKUP\\n' — Android backup magic (alternate spacing)", "weight": 0.9 }
+    ],
+    "matchMode": "any",
+    "MinimumScore": 0.9,
+    "required": true,
+    "Strength": "Strong",
+    "EntropyHint": { "min": 4.5, "max": 8.0 },
+    "validation": {
+      "minFileSize": 24,
+      "maxSignatureOffset": 0,
+      "note": "Android backup files always start with 'ANDROID BACKUP\\n' (14 ASCII chars + LF = 15 bytes). Followed by version (1-5), compression (0/1), and encryption type lines. High entropy if compressed/encrypted payload."
+    }
+  },
+  "variables": {
+    "abMagic": "",
+    "abVersionByte": 0,
+    "abCompressionFlag": 0,
+    "abEncryptionStart": ""
+  },
+  "blocks": [
+    {
+      "type": "signature",
+      "name": "Android Backup Magic",
+      "offset": 0,
+      "length": 15,
+      "color": "#FF6B6B",
+      "opacity": 0.45,
+      "description": "Android backup file identifier: 14 ASCII bytes 'ANDROID BACKUP' (41 4E 44 52 4F 49 44 20 42 41 43 4B 55 50) followed by LF (0x0A). This text header identifies the file as an Android ADB backup created with `adb backup` command. Introduced in Android 4.0 (ICS, API 14). The header is plain ASCII, not binary — the entire preamble is human-readable newline-delimited text.",
+      "storeAs": "abMagic",
+      "valueType": "ascii"
+    },
+    {
+      "type": "field",
+      "name": "Backup Format Version",
+      "offset": 15,
+      "length": 1,
+      "color": "#4ECDC4",
+      "opacity": 0.35,
+      "description": "Single ASCII digit indicating the Android Backup format version followed by LF at offset 16. Version 1=Android 4.0 ICS (app data only), 2=Android 4.1 JB (shared storage added), 3=Android 4.2 (multi-user support), 4=Android 4.4 KitKat, 5=Android 6.0 Marshmallow (full backup API with allowBackup manifest flag). Higher versions may include additional header fields.",
+      "storeAs": "abVersionByte",
+      "valueType": "uint8",
+      "valueMap": {
+        "49": "Version 1 — Android 4.0 ICS (app data only)",
+        "50": "Version 2 — Android 4.1 JB (+ shared storage)",
+        "51": "Version 3 — Android 4.2 (multi-user support)",
+        "52": "Version 4 — Android 4.4 KitKat",
+        "53": "Version 5 — Android 6.0 Marshmallow (full backup)"
+      }
+    },
+    {
+      "type": "field",
+      "name": "Compression Flag",
+      "offset": 17,
+      "length": 1,
+      "color": "#95E1D3",
+      "opacity": 0.35,
+      "description": "Single ASCII character '1' (0x31) or '0' (0x30) at offset 17, indicating whether the TAR payload is compressed with zlib deflate. Value '1' (0x31): payload is zlib-compressed TAR data. Value '0' (0x30): payload is uncompressed TAR data. Followed by LF (0x0A) at offset 18. Most modern backups use compression=1.",
+      "storeAs": "abCompressionFlag",
+      "valueType": "uint8",
+      "valueMap": {
+        "49": "1 — zlib deflate compressed TAR payload",
+        "48": "0 — uncompressed TAR payload"
+      }
+    },
+    {
+      "type": "field",
+      "name": "Encryption Type",
+      "offset": 19,
+      "length": 4,
+      "color": "#FFE66D",
+      "opacity": 0.35,
+      "description": "First 4 bytes of the encryption type string at offset 19 (after compression flag + LF). 'none' (6E 6F 6E 65) = unencrypted TAR follows. 'AES-' (41 45 53 2D) = full string is 'AES-256' — payload encrypted with AES-256 CBC using PBKDF2-derived key. If encrypted, additional header lines follow: userSalt (hex), checksumSalt (hex), rounds (int), masterKeyIV (hex), masterKeyBlob (hex). After last header LF, encrypted data begins.",
+      "storeAs": "abEncryptionStart",
+      "valueType": "ascii",
+      "valueMap": {
+        "none": "No encryption — TAR payload accessible directly",
+        "AES-": "AES-256 CBC encryption — requires password to decrypt"
+      }
+    },
+    {
+      "type": "metadata",
+      "name": "Backup Magic",
+      "variable": "abMagic",
+      "description": "'ANDROID BACKUP' — adb backup file identifier"
+    },
+    {
+      "type": "metadata",
+      "name": "Format Version",
+      "variable": "abVersionByte",
+      "description": "Backup format version (ASCII digit '1'-'5')"
+    },
+    {
+      "type": "metadata",
+      "name": "Compression",
+      "variable": "abCompressionFlag",
+      "description": "Payload compression: '1'=zlib deflate, '0'=raw TAR"
+    },
+    {
+      "type": "metadata",
+      "name": "Encryption",
+      "variable": "abEncryptionStart",
+      "description": "Encryption type: 'none' or 'AES-' (AES-256 CBC)"
+    }
+  ],
+  "assertions": [
+    {
+      "name": "Android Backup magic valid",
+      "expression": "abMagic == 'ANDROID BACKUP'",
+      "severity": "error",
+      "message": "Android backup must start with 'ANDROID BACKUP\\n' — not a valid .ab backup file"
+    },
+    {
+      "name": "Version digit valid",
+      "expression": "abVersionByte >= 49 && abVersionByte <= 57",
+      "severity": "error",
+      "message": "Version byte must be ASCII '1'-'9' (0x31-0x39). Value outside this range indicates corrupt header."
+    },
+    {
+      "name": "Compression flag valid",
+      "expression": "abCompressionFlag == 48 || abCompressionFlag == 49",
+      "severity": "error",
+      "message": "Compression flag must be '0' (uncompressed) or '1' (zlib deflate). Invalid value indicates corrupt or non-standard backup."
+    },
+    {
+      "name": "Encryption type check",
+      "expression": "abEncryptionStart == 'none' || abEncryptionStart == 'AES-'",
+      "severity": "warning",
+      "message": "Encryption type should be 'none' or 'AES-256'. Unknown value may indicate unsupported format variant."
+    },
+    {
+      "name": "Unencrypted backup warning",
+      "expression": "abEncryptionStart == 'AES-'",
+      "severity": "info",
+      "message": "Backup is not encrypted (type='none'). Contains sensitive device data without password protection — potential security risk."
+    }
+  ],
+  "navigation": {
+    "bookmarks": [
+      { "name": "Backup Header", "offset": 0, "icon": "\uE8B7", "color": "#FF6B6B" },
+      { "name": "Version Line", "offset": 15, "icon": "\uE8B7", "color": "#4ECDC4" },
+      { "name": "Compression Line", "offset": 17, "icon": "\uE8B7", "color": "#95E1D3" },
+      { "name": "Encryption Line", "offset": 19, "icon": "\uE8B7", "color": "#FFE66D" }
+    ]
+  },
+  "inspector": {
+    "badge": "abEncryptionStart",
+    "primaryField": "abVersionByte",
+    "showQualityScore": true,
+    "groups": [
+      {
+        "title": "Backup Header",
+        "icon": "\uE8B7",
+        "fields": ["abMagic", "abVersionByte", "abCompressionFlag", "abEncryptionStart"]
+      }
+    ]
+  },
+  "exportTemplates": [
+    {
+      "name": "Android Backup Header (JSON)",
+      "format": "json",
+      "fields": ["abMagic", "abVersionByte", "abCompressionFlag", "abEncryptionStart"]
+    },
+    {
+      "name": "Backup Info (Text)",
+      "format": "text",
+      "fields": ["abVersionByte", "abCompressionFlag", "abEncryptionStart"]
+    }
+  ],
+  "forensic": {
+    "category": "archive",
+    "riskLevel": "high",
+    "suspiciousPatterns": [
+      {
+        "name": "Unencrypted backup",
+        "condition": "abEncryptionStart == 'none'",
+        "severity": "warning",
+        "description": "Backup is not AES-256 encrypted. Contains plaintext TAR archive with full app data, contacts, messages, accounts, and potentially credentials. Common forensic acquisition target."
+      },
+      {
+        "name": "Sensitive data container",
+        "condition": "true",
+        "severity": "info",
+        "description": "Android .ab files may contain: SMS/MMS messages, call logs, app databases (WhatsApp, Signal, banking apps), browser bookmarks/history, credentials stored in apps, photos if shared storage included. High forensic value."
+      }
+    ]
+  },
+  "aiHints": {
+    "analysisContext": "Android Backup .ab format: text header + TAR payload. Header: 'ANDROID BACKUP\\n' + version(1-5)\\n + compression(0/1)\\n + encryption(none/AES-256)\\n [+ PBKDF2 params if encrypted]. Payload: zlib-compressed TAR (if compression=1) or plain TAR. TAR contains apps/ directory (per-app data) and shared/ (external storage). Tool: android-backup-extractor (ABE) — `java -jar abe.jar unpack backup.ab backup.tar [password]`. Then: `tar xf backup.tar`. App data at apps/<package>/db/, apps/<package>/f/, apps/<package>/sp/ (SharedPreferences). Each app database is a standard SQLite file.",
+    "suggestedInspections": [
+      "Bytes 0-14: 'ANDROID BACKUP\\n' magic confirmation",
+      "Byte 15: version digit — higher version = more data types included",
+      "Byte 17: '0' or '1' — if '0', TAR starts ~offset 22; if '1', deflate-compressed TAR starts",
+      "Bytes 19+: 'none' = TAR accessible, 'AES-256' = password required for ABE tool",
+      "After unpack: search apps/ for *.db SQLite files — WhatsApp at apps/com.whatsapp/db/msgstore.db"
+    ]
+  },
+  "software": [
+    "adb (Android Debug Bridge — `adb backup -all -apk -shared -f backup.ab`)",
+    "android-backup-extractor (ABE — Java CLI to unpack .ab to .tar)",
+    "Android Backup Extractor GUI (Windows GUI for ABE)",
+    "UFED (Cellebrite forensic tool — reads .ab natively)",
+    "Oxygen Forensics Detective (mobile forensics platform)"
+  ],
+  "formatRelationships": {
+    "category": "Archives",
+    "extensions": [".ab"],
+    "relatedFormats": ["TAR", "ZIP"],
+    "note": "Android .ab payload is a TAR archive (POSIX format), optionally zlib-deflate compressed and AES-256 encrypted. After decryption/decompression with ABE, standard tar tools can extract contents. Android 12+ deprecated `adb backup` in favor of cloud backup APIs. Some forensic tools can acquire .ab from Android devices directly."
+  },
+  "MimeTypes": ["application/octet-stream"],
+  "UseCases": [
+    "Forensic extraction of Android app data (messages, contacts, app databases)",
+    "Device migration — transferring app data between Android devices",
+    "App data backup for sideloaded or non-cloud-backed apps",
+    "Security audit of app data stored in Android backup"
+  ],
+  "QualityMetrics": {
+    "CompletenessScore": 88,
+    "DocumentationLevel": "detailed",
+    "BlocksDefined": 8,
+    "ValidationRules": 5,
+    "LastUpdated": "2026-04-14",
+    "PriorityFormat": false,
+    "AutoRefined": false
+  },
+  "TechnicalDetails": {
+    "Format": "Text header + zlib-compressed TAR (optionally AES-256 encrypted)",
+    "Magic": "'ANDROID BACKUP\\n' (14 ASCII chars + LF = 15 bytes) at offset 0",
+    "Header": "Newline-delimited ASCII: magic + version + compression + encryption [+ PBKDF2 params]",
+    "Payload": "POSIX TAR archive, zlib-compressed if flag=1, AES-256 CBC if encrypted",
+    "Encryption": "AES-256 CBC; key derived via PBKDF2-HMAC-SHA1, 10000 iterations default",
+    "Tool": "android-backup-extractor (ABE): java -jar abe.jar unpack backup.ab backup.tar [password]"
+  }
+}

--- a/Sources/Core/WpfHexEditor.Core.Definitions/FormatDefinitions/Archives/CPIO.whfmt
+++ b/Sources/Core/WpfHexEditor.Core.Definitions/FormatDefinitions/Archives/CPIO.whfmt
@@ -1,0 +1,380 @@
+{
+  "diffMode": "binary",
+  "formatName": "CPIO Archive",
+  "version": "1.0",
+  "extensions": [".cpio"],
+  "description": "CPIO (Copy In/Out) is a Unix archive format used in Linux initramfs, RPM packages, and system administration. Three main variants exist: 'New ASCII' (SVR4/GNU cpio) with magic '070701' is the most common and used in initramfs; 'New CRC' with magic '070702' adds CRC verification; and the legacy binary format with magic 0x71C7 (little-endian) or 0xC771 (big-endian). Each archive entry consists of a header followed by a null-terminated filename padded to a 4-byte boundary, then file data also padded to a 4-byte boundary. The archive terminates with a special trailer entry named 'TRAILER!!!' (10 bytes). The newc header is 110 bytes with all numeric fields encoded as 8-digit zero-padded uppercase hexadecimal ASCII strings.",
+  "category": "Archives",
+  "author": "WPFHexaEditor Team",
+  "preferredEditor": "hex-editor",
+  "references": {
+    "specifications": [
+      "POSIX.1-2001 cpio Archive Format",
+      "SVR4 cpio(4) New ASCII (newc) Format Specification",
+      "GNU cpio Manual — Format Description"
+    ],
+    "WebLinks": [
+      "https://www.gnu.org/software/cpio/manual/cpio.html",
+      "https://en.wikipedia.org/wiki/Cpio",
+      "https://man7.org/linux/man-pages/man5/cpio.5.html"
+    ]
+  },
+  "detection": {
+    "signatures": [
+      { "value": "303730373031", "offset": 0, "label": "'070701' — CPIO New ASCII (SVR4/newc) format magic", "weight": 1.0 },
+      { "value": "303730373032", "offset": 0, "label": "'070702' — CPIO New CRC format magic", "weight": 1.0 },
+      { "value": "C771", "offset": 0, "label": "0xC771 — CPIO binary format magic (big-endian)", "weight": 0.8 },
+      { "value": "71C7", "offset": 0, "label": "0x71C7 — CPIO binary format magic (little-endian)", "weight": 0.8 }
+    ],
+    "matchMode": "any",
+    "MinimumScore": 0.8,
+    "required": true,
+    "Strength": "Strong",
+    "EntropyHint": { "min": 3.0, "max": 8.0 },
+    "validation": {
+      "minFileSize": 110,
+      "maxSignatureOffset": 0,
+      "note": "New ASCII (newc) format starts with 6 ASCII bytes '070701' or '070702'. Binary format starts with 2-byte magic 0x71C7 or 0xC771. The newc 110-byte header uses 8-digit hex ASCII fields exclusively."
+    }
+  },
+  "variables": {
+    "cpioMagic": "",
+    "cpioIno": "",
+    "cpioMode": "",
+    "cpioUid": "",
+    "cpioGid": "",
+    "cpioNlink": "",
+    "cpioMtime": "",
+    "cpioFilesize": "",
+    "cpioDevmajor": "",
+    "cpioDevminor": "",
+    "cpioRdevmajor": "",
+    "cpioRdevminor": "",
+    "cpioNamesize": "",
+    "cpioCheck": ""
+  },
+  "blocks": [
+    {
+      "type": "signature",
+      "name": "CPIO Magic",
+      "offset": 0,
+      "length": 6,
+      "color": "#FF6B6B",
+      "opacity": 0.45,
+      "description": "CPIO format magic identifier: 6 ASCII bytes. '070701' (30 37 30 37 30 31) for New ASCII (newc/SVR4) format — the most common variant, used in Linux initramfs and RPM archives. '070702' (30 37 30 37 30 32) for New CRC format — identical layout but with a CRC32 checksum in the check field. These are literal ASCII digit strings, not binary values.",
+      "storeAs": "cpioMagic",
+      "valueType": "ascii"
+    },
+    {
+      "type": "field",
+      "name": "Inode Number",
+      "offset": 6,
+      "length": 8,
+      "color": "#4ECDC4",
+      "opacity": 0.35,
+      "description": "Inode number of the archived file, stored as an 8-digit zero-padded hexadecimal ASCII string. Used to detect hard links within the archive — entries with the same inode number and device number reference the same file. Only the first occurrence carries the file data; subsequent entries are hard link stubs.",
+      "storeAs": "cpioIno",
+      "valueType": "ascii"
+    },
+    {
+      "type": "field",
+      "name": "File Mode",
+      "offset": 14,
+      "length": 8,
+      "color": "#95E1D3",
+      "opacity": 0.35,
+      "description": "File mode and permissions stored as an 8-digit zero-padded hexadecimal ASCII string. Encodes both the file type (upper 4 bits: 0x8000=regular, 0x4000=directory, 0xA000=symlink, 0x6000=block device, 0x2000=char device, 0x1000=FIFO) and Unix permission bits (lower 12 bits: owner/group/other rwx plus setuid/setgid/sticky).",
+      "storeAs": "cpioMode",
+      "valueType": "ascii"
+    },
+    {
+      "type": "field",
+      "name": "User ID",
+      "offset": 22,
+      "length": 8,
+      "color": "#FFE66D",
+      "opacity": 0.35,
+      "description": "Numeric owner user ID stored as an 8-digit zero-padded hexadecimal ASCII string. Represents the Unix UID of the file owner at the time of archiving. For initramfs entries this is typically 0 (root).",
+      "storeAs": "cpioUid",
+      "valueType": "ascii"
+    },
+    {
+      "type": "field",
+      "name": "Group ID",
+      "offset": 30,
+      "length": 8,
+      "color": "#C7CEEA",
+      "opacity": 0.35,
+      "description": "Numeric group ID stored as an 8-digit zero-padded hexadecimal ASCII string. Represents the Unix GID of the file's group at the time of archiving. For initramfs entries this is typically 0 (root).",
+      "storeAs": "cpioGid",
+      "valueType": "ascii"
+    },
+    {
+      "type": "field",
+      "name": "Number of Hard Links",
+      "offset": 38,
+      "length": 8,
+      "color": "#B8B8FF",
+      "opacity": 0.35,
+      "description": "Number of hard links to this file, stored as an 8-digit zero-padded hexadecimal ASCII string. For directories this is at least 2 (self + parent). For regular files, values greater than 1 indicate additional hard link entries elsewhere in the archive sharing the same inode number.",
+      "storeAs": "cpioNlink",
+      "valueType": "ascii"
+    },
+    {
+      "type": "field",
+      "name": "Modification Time",
+      "offset": 46,
+      "length": 8,
+      "color": "#FF6B9D",
+      "opacity": 0.35,
+      "description": "Last modification time stored as an 8-digit zero-padded hexadecimal ASCII string representing a Unix timestamp (seconds since 1970-01-01 00:00:00 UTC). Used to restore the file's modification time during extraction.",
+      "storeAs": "cpioMtime",
+      "valueType": "ascii"
+    },
+    {
+      "type": "field",
+      "name": "File Size",
+      "offset": 54,
+      "length": 8,
+      "color": "#C44569",
+      "opacity": 0.35,
+      "description": "Size of the file data in bytes, stored as an 8-digit zero-padded hexadecimal ASCII string. For regular files this is the actual content length. For directories and special files this is 0. For symbolic links this is the length of the target path string. The file data follows the filename, padded to the next 4-byte boundary.",
+      "storeAs": "cpioFilesize",
+      "valueType": "ascii"
+    },
+    {
+      "type": "field",
+      "name": "Device Major Number",
+      "offset": 62,
+      "length": 8,
+      "color": "#98D8C8",
+      "opacity": 0.3,
+      "description": "Major number of the device containing the archived file, stored as an 8-digit zero-padded hexadecimal ASCII string. Combined with devminor to uniquely identify the source filesystem device. Used with inode number to detect hard links across devices.",
+      "storeAs": "cpioDevmajor",
+      "valueType": "ascii"
+    },
+    {
+      "type": "field",
+      "name": "Device Minor Number",
+      "offset": 70,
+      "length": 8,
+      "color": "#FFA07A",
+      "opacity": 0.3,
+      "description": "Minor number of the device containing the archived file, stored as an 8-digit zero-padded hexadecimal ASCII string. Combined with devmajor to uniquely identify the source filesystem device.",
+      "storeAs": "cpioDevminor",
+      "valueType": "ascii"
+    },
+    {
+      "type": "field",
+      "name": "Rdev Major Number",
+      "offset": 78,
+      "length": 8,
+      "color": "#A8E6CF",
+      "opacity": 0.3,
+      "description": "Major device number for character and block device entries, stored as an 8-digit zero-padded hexadecimal ASCII string. Only meaningful when the file mode indicates a device node (character 0x2000 or block 0x6000). Zero for regular files and directories.",
+      "storeAs": "cpioRdevmajor",
+      "valueType": "ascii"
+    },
+    {
+      "type": "field",
+      "name": "Rdev Minor Number",
+      "offset": 86,
+      "length": 8,
+      "color": "#D4A5FF",
+      "opacity": 0.3,
+      "description": "Minor device number for character and block device entries, stored as an 8-digit zero-padded hexadecimal ASCII string. Only meaningful when the file mode indicates a device node. Zero for regular files and directories.",
+      "storeAs": "cpioRdevminor",
+      "valueType": "ascii"
+    },
+    {
+      "type": "field",
+      "name": "Filename Size",
+      "offset": 94,
+      "length": 8,
+      "color": "#FFB347",
+      "opacity": 0.35,
+      "description": "Length of the filename including the null terminator, stored as an 8-digit zero-padded hexadecimal ASCII string. The filename immediately follows the 110-byte header and is padded to the next 4-byte boundary. The trailer entry has namesize=0x0000000B (11 bytes for 'TRAILER!!!' + null).",
+      "storeAs": "cpioNamesize",
+      "valueType": "ascii"
+    },
+    {
+      "type": "field",
+      "name": "Checksum",
+      "offset": 102,
+      "length": 8,
+      "color": "#87CEEB",
+      "opacity": 0.3,
+      "description": "CRC32 checksum of the file data, stored as an 8-digit zero-padded hexadecimal ASCII string. For '070701' (newc) format this field is always '00000000'. For '070702' (newc CRC) format this contains the sum of all bytes in the file data, providing integrity verification.",
+      "storeAs": "cpioCheck",
+      "valueType": "ascii"
+    },
+    {
+      "type": "metadata",
+      "name": "Magic String",
+      "variable": "cpioMagic",
+      "description": "CPIO format variant identifier: '070701' (newc) or '070702' (newc CRC)"
+    },
+    {
+      "type": "metadata",
+      "name": "First Entry Inode",
+      "variable": "cpioIno",
+      "description": "Inode number of the first entry in hexadecimal ASCII representation"
+    },
+    {
+      "type": "metadata",
+      "name": "First Entry Mode",
+      "variable": "cpioMode",
+      "description": "File type and permissions of the first entry in hexadecimal ASCII representation"
+    },
+    {
+      "type": "metadata",
+      "name": "First Entry Size",
+      "variable": "cpioFilesize",
+      "description": "File data size of the first entry in hexadecimal ASCII representation"
+    },
+    {
+      "type": "metadata",
+      "name": "First Entry Name Size",
+      "variable": "cpioNamesize",
+      "description": "Filename length (including null) of the first entry in hexadecimal ASCII"
+    },
+    {
+      "type": "metadata",
+      "name": "Checksum Value",
+      "variable": "cpioCheck",
+      "description": "CRC32 checksum — '00000000' for newc (070701), computed value for CRC format (070702)"
+    }
+  ],
+  "assertions": [
+    {
+      "name": "CPIO magic valid",
+      "expression": "cpioMagic == '070701' || cpioMagic == '070702'",
+      "severity": "error",
+      "message": "CPIO newc archive must start with magic '070701' or '070702' — file is not a valid CPIO new ASCII archive."
+    },
+    {
+      "name": "Filename size non-zero",
+      "expression": "cpioNamesize != '00000000'",
+      "severity": "error",
+      "message": "CPIO namesize field must be greater than zero — every entry requires at least a null-terminated filename of 1 byte."
+    },
+    {
+      "name": "Filesize valid hex ASCII",
+      "field": "cpioFilesize",
+      "condition": "cpioFilesize != ''",
+      "severity": "warning",
+      "message": "CPIO filesize field should be a valid 8-digit hexadecimal ASCII string. Empty or malformed value indicates header corruption."
+    },
+    {
+      "name": "Checksum zero for newc format",
+      "expression": "cpioMagic != '070701' || cpioCheck == '00000000'",
+      "severity": "warning",
+      "message": "CPIO newc (070701) format should have checksum field set to '00000000'. Non-zero value in newc format may indicate format mismatch or corruption."
+    }
+  ],
+  "navigation": {
+    "bookmarks": [
+      { "name": "CPIO Magic", "offset": 0, "icon": "\uE8B7", "color": "#FF6B6B" },
+      { "name": "File Mode", "offset": 14, "icon": "\uE8B7", "color": "#95E1D3" },
+      { "name": "File Size", "offset": 54, "icon": "\uE8B7", "color": "#C44569" },
+      { "name": "Filename Size", "offset": 94, "icon": "\uE8B7", "color": "#FFB347" },
+      { "name": "Checksum", "offset": 102, "icon": "\uE8B7", "color": "#87CEEB" }
+    ]
+  },
+  "inspector": {
+    "badge": "cpioMagic",
+    "primaryField": "cpioFilesize",
+    "showQualityScore": true,
+    "groups": [
+      {
+        "title": "CPIO Header",
+        "icon": "\uE8B7",
+        "fields": ["cpioMagic", "cpioIno", "cpioMode", "cpioUid", "cpioGid"]
+      },
+      {
+        "title": "Entry Data",
+        "icon": "\uE8A5",
+        "fields": ["cpioNlink", "cpioMtime", "cpioFilesize", "cpioNamesize", "cpioCheck"]
+      },
+      {
+        "title": "Device Numbers",
+        "icon": "\uE964",
+        "fields": ["cpioDevmajor", "cpioDevminor", "cpioRdevmajor", "cpioRdevminor"]
+      }
+    ]
+  },
+  "exportTemplates": [
+    {
+      "name": "CPIO Header (JSON)",
+      "format": "json",
+      "fields": ["cpioMagic", "cpioIno", "cpioMode", "cpioUid", "cpioGid", "cpioNlink", "cpioMtime", "cpioFilesize", "cpioNamesize", "cpioCheck"]
+    },
+    {
+      "name": "CPIO Entry Summary (Text)",
+      "format": "text",
+      "fields": ["cpioMagic", "cpioMode", "cpioFilesize", "cpioNamesize"]
+    }
+  ],
+  "forensic": {
+    "category": "archive",
+    "riskLevel": "low",
+    "suspiciousPatterns": [
+      {
+        "name": "Setuid/setgid binary in archive",
+        "condition": "cpioMode contains setuid or setgid bits",
+        "severity": "warning",
+        "description": "CPIO archive entry has setuid/setgid bits set in file mode. This is common in initramfs but suspicious in user-supplied archives as it may indicate privilege escalation payloads."
+      }
+    ]
+  },
+  "aiHints": {
+    "analysisContext": "CPIO newc format: 110-byte ASCII header per entry, all numeric fields as 8-digit hex strings. Filename follows header (padded to 4-byte boundary), then file data (padded to 4-byte boundary). Archive ends with 'TRAILER!!!' entry. Most common in Linux initramfs (cpio.gz) and as the inner archive format of RPM packages. No built-in compression — typically wrapped in gzip.",
+    "suggestedInspections": [
+      "Bytes 0-5: verify magic '070701' (newc) or '070702' (CRC) — all 6 bytes are ASCII digits",
+      "Bytes 54-61: filesize hex string — convert to integer to locate file data boundary",
+      "Bytes 94-101: namesize hex string — convert to find filename at offset 110, then data at 110+padded(namesize)",
+      "Bytes 102-109: check field — must be '00000000' for 070701, CRC32 sum for 070702",
+      "Scan for 'TRAILER!!!' (54 52 41 49 4C 45 52 21 21 21) to locate archive end marker",
+      "For initramfs analysis: decompress outer gzip first, then parse sequential CPIO entries"
+    ]
+  },
+  "software": [
+    "cpio (GNU cpio — standard Unix archive tool)",
+    "rpm2cpio (extract CPIO archive from RPM packages)",
+    "dracut (Linux initramfs generator — creates cpio.gz images)",
+    "mkinitcpio (Arch Linux initramfs creation tool)",
+    "7-Zip (cross-platform archive tool with CPIO support)"
+  ],
+  "formatRelationships": {
+    "category": "Archives",
+    "extensions": [".cpio"],
+    "relatedFormats": ["TAR", "GZIP", "RPM"],
+    "note": "CPIO is the inner archive format of RPM packages (rpm2cpio extracts it). Linux initramfs images are gzip-compressed CPIO archives. Often compared to TAR — both are sequential archive formats, but CPIO has simpler fixed-width headers. Modern Linux favors CPIO for initramfs due to simpler kernel decompression code."
+  },
+  "MimeTypes": ["application/x-cpio"],
+  "UseCases": [
+    "Linux initramfs boot filesystem images (cpio.gz archive)",
+    "RPM package inner archive (rpm2cpio extraction target)",
+    "System backup and restore on Unix/Linux platforms",
+    "Firmware image analysis and embedded system forensics"
+  ],
+  "QualityMetrics": {
+    "CompletenessScore": 90,
+    "DocumentationLevel": "comprehensive",
+    "BlocksDefined": 20,
+    "ValidationRules": 4,
+    "LastUpdated": "2026-04-14",
+    "PriorityFormat": false,
+    "AutoRefined": false
+  },
+  "TechnicalDetails": {
+    "Format": "Sequential archive with fixed-width ASCII headers and 4-byte aligned entries",
+    "Magic": "'070701' (newc) or '070702' (CRC) — 6 ASCII bytes at offset 0",
+    "HeaderSize": 110,
+    "FieldEncoding": "8-digit zero-padded uppercase hexadecimal ASCII strings",
+    "BlockAlignment": 4,
+    "TrailerEntry": "'TRAILER!!!' (10 bytes + null) marks end of archive",
+    "Endianness": "N/A for newc (hex ASCII strings); binary variant uses native byte order",
+    "MaxFileSize": "4 GiB (32-bit hex field limit: 0xFFFFFFFF)"
+  }
+}

--- a/Sources/Core/WpfHexEditor.Core.Definitions/FormatDefinitions/Archives/WARC.whfmt
+++ b/Sources/Core/WpfHexEditor.Core.Definitions/FormatDefinitions/Archives/WARC.whfmt
@@ -1,0 +1,231 @@
+{
+  "diffMode": "text",
+  "formatName": "WARC Web Archive",
+  "version": "1.0",
+  "extensions": [".warc", ".warc.gz"],
+  "description": "WARC (Web ARChive) is an ISO 28500 standard format for storing web crawl data, used by the Internet Archive's Wayback Machine, Common Crawl, and web preservation projects worldwide. A WARC file is a sequence of records, each consisting of a text header followed by a content block. Each record starts with the version line 'WARC/1.0' or 'WARC/1.1' (ASCII). WARC headers are key-value pairs including WARC-Type (warcinfo, request, response, resource, metadata, revisit, conversion, continuation), WARC-Date (ISO 8601), WARC-Record-ID (URN UUID), Content-Length, Content-Type, and WARC-Target-URI. A blank CRLF line separates header from content, and two blank CRLF lines separate consecutive records. Response records contain the full HTTP response including status line, headers, and body.",
+  "category": "Archives",
+  "author": "WPFHexaEditor Team",
+  "preferredEditor": "hex-editor",
+  "references": {
+    "specifications": [
+      "ISO 28500:2017 — WARC File Format",
+      "ISO 28500:2009 — WARC File Format (original edition)",
+      "IIPC WARC Implementation Guidelines"
+    ],
+    "WebLinks": [
+      "https://iipc.github.io/warc-specifications/specifications/warc-format/warc-1.1/",
+      "https://en.wikipedia.org/wiki/WARC_(file_format)",
+      "https://commoncrawl.org/the-data/get-started/"
+    ]
+  },
+  "detection": {
+    "signatures": [
+      { "value": "574152432F312E30", "offset": 0, "label": "'WARC/1.0' — WARC version 1.0 record header (ISO 28500:2009)", "weight": 1.0 },
+      { "value": "574152432F312E31", "offset": 0, "label": "'WARC/1.1' — WARC version 1.1 record header (ISO 28500:2017)", "weight": 1.0 }
+    ],
+    "matchMode": "any",
+    "MinimumScore": 0.9,
+    "required": true,
+    "Strength": "Strong",
+    "EntropyHint": { "min": 3.5, "max": 7.0 },
+    "validation": {
+      "minFileSize": 10,
+      "maxSignatureOffset": 0,
+      "note": "WARC files always begin with 'WARC/1.0' or 'WARC/1.1' (8 ASCII bytes) followed by CRLF. Compressed .warc.gz files must be decompressed first — each record is individually gzip-compressed for random access. Uncompressed WARC is pure text header + binary/text content."
+    }
+  },
+  "variables": {
+    "warcVersion": "",
+    "warcSeparator": "",
+    "warcTypeLine": "",
+    "warcDateLine": ""
+  },
+  "blocks": [
+    {
+      "type": "signature",
+      "name": "WARC Version Line",
+      "offset": 0,
+      "length": 8,
+      "color": "#FF6B6B",
+      "opacity": 0.45,
+      "description": "WARC record version identifier: 8 ASCII bytes 'WARC/1.0' (57 41 52 43 2F 31 2E 30) or 'WARC/1.1' (57 41 52 43 2F 31 2E 31). Every WARC record begins with this version line. ISO 28500:2009 defines version 1.0; ISO 28500:2017 defines version 1.1 which adds the 'revisit' profile for deduplication and stricter URI requirements.",
+      "storeAs": "warcVersion",
+      "valueType": "ascii"
+    },
+    {
+      "type": "field",
+      "name": "Version Line Terminator",
+      "offset": 8,
+      "length": 2,
+      "color": "#4ECDC4",
+      "opacity": 0.35,
+      "description": "CRLF (0x0D 0x0A) terminating the version line. WARC mandates CRLF line endings throughout the header section per the ISO 28500 specification. The header continues with key-value pairs on subsequent lines until a blank CRLF line marks the start of the content block.",
+      "storeAs": "warcSeparator",
+      "valueType": "hex",
+      "validation": {
+        "expectedValue": "0D0A"
+      }
+    },
+    {
+      "type": "field",
+      "name": "WARC-Type Header Start",
+      "offset": 10,
+      "length": 10,
+      "color": "#95E1D3",
+      "opacity": 0.35,
+      "description": "Beginning of the first header field, typically 'WARC-Type:' (57 41 52 43 2D 54 79 70 65 3A). The WARC-Type field specifies the record type: 'warcinfo' (crawl metadata), 'request' (HTTP request), 'response' (HTTP response with headers and body), 'resource' (standalone content), 'metadata' (additional info), 'revisit' (deduplicated content), 'conversion' (format-converted content), or 'continuation' (split record).",
+      "storeAs": "warcTypeLine",
+      "valueType": "ascii"
+    },
+    {
+      "type": "metadata",
+      "name": "WARC Version",
+      "variable": "warcVersion",
+      "description": "WARC format version: 'WARC/1.0' (ISO 28500:2009) or 'WARC/1.1' (ISO 28500:2017)"
+    },
+    {
+      "type": "metadata",
+      "name": "Line Terminator",
+      "variable": "warcSeparator",
+      "description": "CRLF line ending after version line — confirms proper WARC formatting"
+    },
+    {
+      "type": "metadata",
+      "name": "First Header Field",
+      "variable": "warcTypeLine",
+      "description": "Start of WARC-Type header — identifies the record type (response, request, warcinfo, etc.)"
+    }
+  ],
+  "assertions": [
+    {
+      "name": "WARC version line valid",
+      "expression": "warcVersion == 'WARC/1.0' || warcVersion == 'WARC/1.1'",
+      "severity": "error",
+      "message": "WARC file must start with 'WARC/1.0' or 'WARC/1.1' — file is not a valid WARC web archive."
+    },
+    {
+      "name": "CRLF line endings required",
+      "field": "warcSeparator",
+      "condition": "warcSeparator == '0D0A'",
+      "severity": "error",
+      "message": "WARC specification requires CRLF (0x0D 0x0A) line endings. LF-only endings violate ISO 28500 and may cause parser failures."
+    },
+    {
+      "name": "WARC-Type header expected",
+      "expression": "warcTypeLine == 'WARC-Type:'",
+      "severity": "warning",
+      "message": "First header after version line is typically 'WARC-Type:'. Different ordering is technically valid but uncommon — may indicate a non-standard WARC generator."
+    }
+  ],
+  "navigation": {
+    "bookmarks": [
+      { "name": "WARC Version", "offset": 0, "icon": "\uE8B7", "color": "#FF6B6B" },
+      { "name": "First Header", "offset": 10, "icon": "\uE8B7", "color": "#95E1D3" }
+    ]
+  },
+  "inspector": {
+    "badge": "warcVersion",
+    "primaryField": "warcTypeLine",
+    "showQualityScore": true,
+    "groups": [
+      {
+        "title": "WARC Record Header",
+        "icon": "\uE8B7",
+        "fields": ["warcVersion", "warcSeparator", "warcTypeLine"]
+      },
+      {
+        "title": "Record Info",
+        "icon": "\uE774",
+        "fields": ["warcDateLine"]
+      }
+    ]
+  },
+  "exportTemplates": [
+    {
+      "name": "WARC Record Header (JSON)",
+      "format": "json",
+      "fields": ["warcVersion", "warcTypeLine"]
+    },
+    {
+      "name": "WARC Summary (Text)",
+      "format": "text",
+      "fields": ["warcVersion", "warcTypeLine"]
+    }
+  ],
+  "forensic": {
+    "category": "archive",
+    "riskLevel": "medium",
+    "suspiciousPatterns": [
+      {
+        "name": "Sensitive HTTP headers in archived responses",
+        "condition": "response records may contain Set-Cookie, Authorization, or session tokens",
+        "severity": "warning",
+        "description": "WARC response records capture complete HTTP responses including authentication cookies, session tokens, Authorization headers, and CSRF tokens. These credentials may still be valid or reveal authentication patterns."
+      },
+      {
+        "name": "Personal data in captured form submissions",
+        "condition": "request records with POST data may contain personal information",
+        "severity": "warning",
+        "description": "WARC request records can contain HTTP POST body data including form submissions with personal information, passwords, credit card numbers, and other sensitive user input captured during the web crawl."
+      },
+      {
+        "name": "Private or restricted page content",
+        "condition": "response records may contain content from authenticated sessions",
+        "severity": "info",
+        "description": "WARC archives may contain web pages captured from authenticated sessions, including private dashboards, internal tools, email content, and documents not intended for public access."
+      }
+    ]
+  },
+  "aiHints": {
+    "analysisContext": "WARC is a text-header + binary-content format per ISO 28500. Each record: version line ('WARC/1.0' or 'WARC/1.1') + CRLF headers (WARC-Type, WARC-Date, WARC-Record-ID, Content-Length, Content-Type, WARC-Target-URI) + blank CRLF + content block (Content-Length bytes) + double CRLF separator. For 'response' records, the content block is a full HTTP response (status line + headers + body). Typically distributed as .warc.gz where each record is individually gzip-compressed for random access via CDX index files.",
+    "suggestedInspections": [
+      "Bytes 0-7: verify 'WARC/1.0' or 'WARC/1.1' ASCII magic — confirms uncompressed WARC format",
+      "Bytes 8-9: must be CRLF (0D 0A) — WARC mandates CRLF line endings per ISO 28500",
+      "Search for 'Content-Length:' header to determine content block size and locate record boundaries",
+      "Search for 'WARC-Target-URI:' to identify the archived URL of each record",
+      "Locate double CRLF (0D 0A 0D 0A) sequences to find header-content boundaries and record separators",
+      "For .warc.gz: each record is individually gzip-compressed — look for 1F 8B gzip headers to find record starts"
+    ]
+  },
+  "software": [
+    "Wayback Machine (archive.org — world's largest WARC archive)",
+    "wget (--warc-file flag generates WARC output during crawl)",
+    "Heritrix (Internet Archive's open-source web crawler)",
+    "warcio (Python library for reading and writing WARC files)",
+    "pywb (Webrecorder replay engine for WARC playback)",
+    "CDX Server (index server for random access into WARC archives)"
+  ],
+  "formatRelationships": {
+    "category": "Archives",
+    "extensions": [".warc", ".warc.gz"],
+    "relatedFormats": ["GZIP", "HTTP"],
+    "note": "WARC files are typically distributed as .warc.gz where each record is individually gzip-compressed to support random access via CDX index files. The content blocks of response records contain raw HTTP responses. WARC superseded the older ARC format used by the Internet Archive before 2009. Related: CDX/CDXJ index files map URLs to WARC record offsets."
+  },
+  "MimeTypes": ["application/warc"],
+  "UseCases": [
+    "Web archiving and digital preservation (Internet Archive, national libraries)",
+    "Common Crawl dataset access and large-scale web corpus analysis",
+    "Legal and compliance web snapshots for regulatory evidence",
+    "Digital forensics — recovering cached web pages and browsing activity",
+    "SEO and marketing competitive analysis via historical web captures"
+  ],
+  "QualityMetrics": {
+    "CompletenessScore": 88,
+    "DocumentationLevel": "comprehensive",
+    "BlocksDefined": 6,
+    "ValidationRules": 3,
+    "LastUpdated": "2026-04-14",
+    "PriorityFormat": false,
+    "AutoRefined": false
+  },
+  "TechnicalDetails": {
+    "Format": "Text header + binary/text content block per record, CRLF-delimited",
+    "Standard": "ISO 28500:2017 (version 1.1), ISO 28500:2009 (version 1.0)",
+    "Magic": "'WARC/1.0' or 'WARC/1.1' (8 ASCII bytes) at offset 0",
+    "LineEndings": "CRLF (0x0D 0x0A) mandatory per specification",
+    "RecordTypes": "warcinfo, request, response, resource, metadata, revisit, conversion, continuation",
+    "Compression": "Typically per-record gzip for random access (.warc.gz)",
+    "MaxRecordSize": "No specification limit — Content-Length field determines size"
+  }
+}

--- a/Sources/Core/WpfHexEditor.Core.Definitions/FormatDefinitions/Certificates/SNK.whfmt
+++ b/Sources/Core/WpfHexEditor.Core.Definitions/FormatDefinitions/Certificates/SNK.whfmt
@@ -1,0 +1,345 @@
+{
+  "diffMode": "binary",
+  "formatName": "Strong Name Key (SNK)",
+  "version": "1.0",
+  "extensions": [ ".snk", ".pfx" ],
+  "description": "Microsoft Strong Name Key file containing a CryptoAPI PRIVATEKEYBLOB or PUBLICKEYBLOB structure with an RSA key pair or public key used to sign .NET assemblies for the Global Assembly Cache.",
+  "category": "Certificates",
+  "author": "WPFHexaEditor Team",
+  "MimeTypes": [ "application/octet-stream", "application/x-snk" ],
+  "UseCases": [
+    "Strong-naming .NET assemblies for Global Assembly Cache (GAC) installation",
+    "Delay-signing assemblies during development with public key only",
+    "Verifying assembly identity and preventing tampering at load time",
+    "NuGet package signing and code integrity verification",
+    "MSBuild and dotnet CLI assembly signing pipeline"
+  ],
+  "software": [
+    { "name": "sn.exe (Strong Name Tool)", "role": "producer/consumer" },
+    { "name": "dotnet CLI (dotnet snk)",    "role": "producer" },
+    { "name": "MSBuild AssemblyOriginatorKeyFile", "role": "consumer" },
+    { "name": "ilasm / ildasm",            "role": "consumer" },
+    { "name": "OpenSSL / BouncyCastle",    "role": "related" }
+  ],
+  "formatRelationships": {
+    "relatedFormats": [ "DER (.der)", "PEM (.pem)", "PFX/PKCS#12 (.pfx)", "PE AssemblySignatureKey attribute" ],
+    "container": null,
+    "notes": "SNK files use the CryptoAPI BLOBHEADER format (wincrypt.h). A full key pair (.snk with PRIVATEKEYBLOB) can be converted to PEM via openssl or sn.exe -p. The public key portion is embedded in the AssemblyDef table of signed PE files."
+  },
+
+  "detection": {
+    "signatures": [
+      {
+        "value": "0702000000240000",
+        "offset": 0,
+        "label": "PRIVATEKEYBLOB header: bType=0x07 PRIVATEKEYBLOB, bVersion=0x02, reserved=0x0000, aiKeyAlg=0x2400 CALG_RSA_SIGN",
+        "weight": 70,
+        "required": false
+      },
+      {
+        "value": "52534132",
+        "offset": 8,
+        "label": "RSA2 magic — private key CRT parameters follow",
+        "weight": 20,
+        "required": false
+      },
+      {
+        "value": "0602000000240000",
+        "offset": 0,
+        "label": "PUBLICKEYBLOB header: bType=0x06, bVersion=0x02, reserved=0x0000, aiKeyAlg=0x2400",
+        "weight": 70,
+        "required": false
+      },
+      {
+        "value": "52534131",
+        "offset": 8,
+        "label": "RSA1 magic — public key modulus follows",
+        "weight": 20,
+        "required": false
+      }
+    ],
+    "matchMode": "weighted",
+    "MinimumScore": 70,
+    "Strength": "Strong",
+    "EntropyHint": {
+      "min": 5.5,
+      "max": 7.9,
+      "note": "RSA key material (prime factors, modulus, exponents) is effectively random; high entropy expected in modulus and private exponent fields."
+    },
+    "validation": {
+      "expression": "(UINT8(0) == 0x07 || UINT8(0) == 0x06) && UINT8(1) == 0x02 && UINT16_LE(2) == 0x0000",
+      "description": "Valid SNK files start with a CryptoAPI BLOBHEADER: bType is 6 (public) or 7 (private), bVersion is 2, reserved is 0."
+    }
+  },
+
+  "variables": {
+    "bType":      { "offset": 0,  "length": 1, "type": "uint8"   },
+    "bVersion":   { "offset": 1,  "length": 1, "type": "uint8"   },
+    "reserved":   { "offset": 2,  "length": 2, "type": "uint16le"},
+    "aiKeyAlg":   { "offset": 4,  "length": 4, "type": "uint32le"},
+    "rsaMagic":   { "offset": 8,  "length": 4, "type": "bytes"   },
+    "bitlen":     { "offset": 12, "length": 4, "type": "uint32le"},
+    "pubExp":     { "offset": 16, "length": 4, "type": "uint32le"},
+    "modulus":    { "offset": 20, "length": "bitlen/8", "type": "bytes" }
+  },
+
+  "blocks": [
+    {
+      "type": "signature",
+      "name": "BLOBHEADER — bType",
+      "offset": 0,
+      "length": 1,
+      "color": "#1A237E",
+      "opacity": 0.9,
+      "description": "CryptoAPI BLOBHEADER bType field identifying the key blob type: 0x06 = PUBLICKEYBLOB (public key only), 0x07 = PRIVATEKEYBLOB (full RSA key pair with CRT parameters).",
+      "storeAs": "bType",
+      "valueType": "uint8",
+      "valueMap": {
+        "6":  "PUBLICKEYBLOB — public key only, safe to distribute",
+        "7":  "PRIVATEKEYBLOB — full RSA key pair, MUST be kept secret",
+        "8":  "PLAINTEXTKEYBLOB — symmetric key (unexpected in .snk)",
+        "10": "OPAQUEKEYBLOB — provider-specific format"
+      }
+    },
+    {
+      "type": "field",
+      "name": "BLOBHEADER — bVersion",
+      "offset": 1,
+      "length": 1,
+      "color": "#283593",
+      "opacity": 0.75,
+      "description": "CryptoAPI BLOBHEADER bVersion; must be 2 (CUR_BLOB_VERSION) for all modern Windows CryptoAPI RSA key blobs; version 1 was used in early Windows NT.",
+      "storeAs": "bVersion",
+      "valueType": "uint8",
+      "valueMap": {
+        "2": "CUR_BLOB_VERSION (Windows NT 4.0+)"
+      }
+    },
+    {
+      "type": "field",
+      "name": "BLOBHEADER — Reserved",
+      "offset": 2,
+      "length": 2,
+      "color": "#9E9E9E",
+      "opacity": 0.4,
+      "description": "Reserved field in CryptoAPI BLOBHEADER; must be zero. Non-zero value indicates file corruption or a custom CryptoAPI provider extension.",
+      "storeAs": "reserved",
+      "valueType": "uint16",
+      "endianness": "little"
+    },
+    {
+      "type": "field",
+      "name": "BLOBHEADER — aiKeyAlg",
+      "offset": 4,
+      "length": 4,
+      "color": "#3949AB",
+      "opacity": 0.8,
+      "description": "CryptoAPI algorithm identifier (ALG_ID from wincrypt.h) specifying the intended use of the key; strong-name SNK files always use CALG_RSA_SIGN (0x2400) for signature verification.",
+      "storeAs": "aiKeyAlg",
+      "valueType": "uint32",
+      "endianness": "little",
+      "valueMap": {
+        "9216":  "CALG_RSA_SIGN (0x2400) — RSA signature key, standard for strong-name SNK",
+        "41984": "CALG_RSA_KEYX (0xA400) — RSA key exchange key",
+        "256":   "CALG_MD5 (unexpected in key blob)",
+        "32772": "CALG_SHA1 (unexpected in key blob)"
+      }
+    },
+    {
+      "type": "signature",
+      "name": "RSA Magic",
+      "offset": 8,
+      "length": 4,
+      "color": "#5C6BC0",
+      "opacity": 0.85,
+      "description": "Four-byte ASCII magic within the RSAPUBKEY/RSAPRIVKEY structure: 'RSA1' (0x31415352) for PUBLICKEYBLOB or 'RSA2' (0x32415352) for PRIVATEKEYBLOB with CRT private parameters.",
+      "storeAs": "rsaMagic",
+      "valueType": "bytes",
+      "valueMap": {
+        "52534131": "RSA1 — public key structure (PUBLICKEYBLOB)",
+        "52534132": "RSA2 — private key structure with CRT parameters (PRIVATEKEYBLOB)"
+      }
+    },
+    {
+      "type": "field",
+      "name": "Key Size (bitlen)",
+      "offset": 12,
+      "length": 4,
+      "color": "#7986CB",
+      "opacity": 0.75,
+      "description": "RSA key size in bits; common values are 1024, 2048, or 4096. The modulus field length equals bitlen/8 bytes. Keys shorter than 2048 bits are considered weak by modern standards.",
+      "storeAs": "bitlen",
+      "valueType": "uint32",
+      "endianness": "little",
+      "valueMap": {
+        "1024": "1024-bit RSA — legacy, considered weak (NIST deprecated)",
+        "2048": "2048-bit RSA — minimum recommended key size",
+        "4096": "4096-bit RSA — high security, larger signing overhead"
+      }
+    },
+    {
+      "type": "field",
+      "name": "Public Exponent (pubExp)",
+      "offset": 16,
+      "length": 4,
+      "color": "#9FA8DA",
+      "opacity": 0.7,
+      "description": "RSA public exponent stored as a 32-bit little-endian value; industry standard is 65537 (0x00010001). Small exponents (3, 17) are computationally efficient but deprecated for signing.",
+      "storeAs": "pubExp",
+      "valueType": "uint32",
+      "endianness": "little",
+      "valueMap": {
+        "3":     "e=3 — historically used but vulnerable to small-message attacks",
+        "17":    "e=17 — Fermat prime F2",
+        "65537": "e=65537 — standard Fermat prime F4, recommended"
+      }
+    },
+    {
+      "type": "field",
+      "name": "Modulus (n)",
+      "offset": 20,
+      "length": "bitlen/8",
+      "color": "#3F51B5",
+      "opacity": 0.65,
+      "description": "RSA modulus of bitlen/8 bytes stored in little-endian byte order; the product of two large prime factors p and q. This value is included in the public key embedded in signed .NET assemblies.",
+      "storeAs": "modulus",
+      "valueType": "bytes"
+    },
+    {
+      "type": "metadata",
+      "name": "CRT Private Parameters (PRIVATEKEYBLOB only)",
+      "offset": "20+(bitlen/8)",
+      "length": "variable",
+      "color": "#C5CAE9",
+      "opacity": 0.6,
+      "description": "Chinese Remainder Theorem private key parameters for PRIVATEKEYBLOB: prime1 (p), prime2 (q), exponent1 (d mod p-1), exponent2 (d mod q-1), coefficient (q^-1 mod p), and private exponent (d). Each field is bitlen/16 bytes except privateExponent (bitlen/8 bytes)."
+    }
+  ],
+
+  "assertions": [
+    {
+      "name": "ValidBlobType",
+      "expression": "UINT8(0) == 6 || UINT8(0) == 7",
+      "severity": "error",
+      "message": "bType at offset 0 is not 6 (PUBLICKEYBLOB) or 7 (PRIVATEKEYBLOB); this is not a valid CryptoAPI RSA key blob."
+    },
+    {
+      "name": "BlobVersionIsTwo",
+      "expression": "UINT8(1) == 2",
+      "severity": "warning",
+      "message": "bVersion at offset 1 is not 2 (CUR_BLOB_VERSION); unexpected version may indicate an unsupported or legacy CryptoAPI format."
+    },
+    {
+      "name": "ReservedIsZero",
+      "expression": "UINT16_LE(2) == 0",
+      "severity": "warning",
+      "message": "Reserved field at offset 2 is non-zero; this may indicate file corruption or a non-standard CryptoAPI provider."
+    },
+    {
+      "name": "AlgorithmIsRSASign",
+      "expression": "UINT32_LE(4) == 0x2400",
+      "severity": "info",
+      "message": "aiKeyAlg is not CALG_RSA_SIGN (0x2400); strong-name SNK files are expected to use CALG_RSA_SIGN. This may be a key exchange key rather than a signing key."
+    },
+    {
+      "name": "ValidRSAMagic",
+      "expression": "UINT32_LE(8) == 0x31415352 || UINT32_LE(8) == 0x32415352",
+      "severity": "error",
+      "message": "RSA magic at offset 8 is not 'RSA1' or 'RSA2'; the RSAPUBKEY structure is corrupt or this is not a standard CryptoAPI RSA key blob."
+    },
+    {
+      "name": "KeySizeReasonable",
+      "expression": "UINT32_LE(12) >= 512 && UINT32_LE(12) <= 16384",
+      "severity": "warning",
+      "message": "Key size (bitlen) is outside the range 512–16384 bits; this value is implausible and may indicate a corrupt key blob."
+    },
+    {
+      "name": "WeakKeyWarning",
+      "expression": "UINT32_LE(12) >= 2048",
+      "severity": "info",
+      "message": "RSA key is shorter than 2048 bits; keys of 1024 bits or less are considered cryptographically weak and should not be used for new assemblies."
+    }
+  ],
+
+  "navigation": {
+    "bookmarks": [
+      { "name": "BLOBHEADER",     "offset": 0,  "description": "CryptoAPI BLOBHEADER — bType, bVersion, reserved, aiKeyAlg" },
+      { "name": "RSAPUBKEY",      "offset": 8,  "description": "RSA key structure — magic (RSA1/RSA2), bitlen, pubExp" },
+      { "name": "Modulus",        "offset": 20, "description": "RSA modulus (n) — bitlen/8 bytes little-endian" },
+      { "name": "CRT Parameters", "offset": "20+(bitlen/8)", "description": "Private key CRT factors (PRIVATEKEYBLOB only)" }
+    ]
+  },
+
+  "inspector": {
+    "badge": "SNK",
+    "primaryField": "bType",
+    "showQualityScore": true,
+    "groups": [
+      {
+        "name": "Blob Header",
+        "fields": [ "bType", "bVersion", "reserved", "aiKeyAlg" ]
+      },
+      {
+        "name": "RSA Key",
+        "fields": [ "rsaMagic", "bitlen", "pubExp" ]
+      },
+      {
+        "name": "Key Material",
+        "fields": [ "modulus" ]
+      }
+    ]
+  },
+
+  "exportTemplates": [
+    {
+      "name": "SNK Key Summary",
+      "format": "text",
+      "template": "Strong Name Key\n  Type       : {bType} ({bType_mapped})\n  Algorithm  : {aiKeyAlg} ({aiKeyAlg_mapped})\n  RSA Magic  : {rsaMagic_mapped}\n  Key Size   : {bitlen} bits\n  Public Exp : {pubExp}"
+    },
+    {
+      "name": "SNK JSON Report",
+      "format": "json",
+      "template": "{ \"format\": \"SNK\", \"blobType\": {bType}, \"algorithm\": {aiKeyAlg}, \"keySizeBits\": {bitlen}, \"publicExponent\": {pubExp} }"
+    }
+  ],
+
+  "forensic": {
+    "category": "CryptographicKey",
+    "riskLevel": "high",
+    "suspiciousPatterns": [
+      { "pattern": "PrivateKeyExposed",   "description": "PRIVATEKEYBLOB (bType=7) in a public repository or build artifact exposes the RSA private key, enabling assembly spoofing and signature forgery." },
+      { "pattern": "WeakKeySize",         "description": "RSA key shorter than 2048 bits is cryptographically weak; NIST deprecated 1024-bit keys after 2013." },
+      { "pattern": "NonStandardExponent", "description": "Public exponent other than 65537 may indicate a key generated by unusual tooling; exponent 3 is vulnerable to certain attacks." },
+      { "pattern": "KeyExchangeAlgorithm","description": "aiKeyAlg = CALG_RSA_KEYX in a .snk file is unexpected; strong-name keys should use CALG_RSA_SIGN." }
+    ]
+  },
+
+  "aiHints": {
+    "analysisContext": "SNK files contain CryptoAPI RSA key blobs used to strong-name .NET assemblies. A PRIVATEKEYBLOB includes the full key pair (public modulus, exponent, and CRT private parameters). The public portion is hashed (SHA-1) and embedded in the assembly's strong name identity. Exposure of private SNK files undermines assembly identity guarantees.",
+    "suggestedInspections": [
+      "Check bType to determine if this is a full private key (0x07) or public-only key (0x06) — private keys must never be committed to source control.",
+      "Verify bitlen is at least 2048 bits; 1024-bit strong-name keys are deprecated and should be regenerated.",
+      "Extract the modulus bytes and compute SHA-1 to derive the expected strong name public key token (last 8 bytes reversed).",
+      "Compare the public exponent against 65537 (0x00010001) — non-standard exponents warrant investigation.",
+      "For PRIVATEKEYBLOB, verify the file size matches the expected size: 20 + 5*(bitlen/16) + (bitlen/8) bytes."
+    ]
+  },
+
+  "TechnicalDetails": {
+    "specification": "wincrypt.h BLOBHEADER, RSAPUBKEY structures; Microsoft documentation 'CryptImportKey / CryptExportKey'; ECMA-335 §I.6.2 Strong Names; .NET strong naming specification",
+    "endianness": "little-endian for all multi-byte integer fields",
+    "privateKeyBlobSize": "20 + 5*(bitlen/16) + (bitlen/8) bytes for CRT parameters",
+    "publicKeyBlobSize":  "20 + (bitlen/8) bytes",
+    "notes": "The SNK format is a raw CryptoAPI blob, not a PEM or DER certificate. sn.exe -p extracts the public key. sn.exe -tp displays the public key token. The token is derived as ToLittleEndian(SHA1(publicKey)[12..19])."
+  },
+
+  "QualityMetrics": {
+    "CompletenessScore": 92,
+    "DocumentationLevel": "comprehensive",
+    "BlocksDefined": 9,
+    "ValidationRules": 7,
+    "LastUpdated": "2026-04-14",
+    "PriorityFormat": true,
+    "AutoRefined": false
+  }
+}

--- a/Sources/Core/WpfHexEditor.Core.Definitions/FormatDefinitions/Data/WHFMT.whfmt
+++ b/Sources/Core/WpfHexEditor.Core.Definitions/FormatDefinitions/Data/WHFMT.whfmt
@@ -1,0 +1,416 @@
+{
+  "diffMode": "text",
+  "formatName": "WPFHexaEditor Format Definition",
+  "version": "1.0",
+  "extensions": [
+    ".whfmt"
+  ],
+  "mimeTypes": [
+    "application/json",
+    "application/vnd.wpfhexaeditor.format+json"
+  ],
+  "description": "The .whfmt format is the native format definition schema for WPFHexaEditor. Each .whfmt file is a JSON document that describes a binary or text file format — its detection signatures, header structure, block layout, variables, assertions, forensic patterns, and rendering hints. This is the meta-format: the format definition that describes format definitions themselves. Yes, it is self-referential. Yes, we find it amusing.",
+  "category": "Data",
+  "author": "WPFHexaEditor Team",
+  "preferredEditor": "structure-editor",
+  "references": {
+    "specifications": [
+      "WPFHexaEditor .whfmt Schema v2",
+      "whfmt.schema.json (embedded in WpfHexEditor.Core.Definitions)"
+    ],
+    "WebLinks": [
+      "https://github.com/abbaye/WpfHexEditorControl"
+    ]
+  },
+  "detection": {
+    "signature": "7B",
+    "offset": 0,
+    "required": false,
+    "Strength": "Weak",
+    "EntropyHint": { "min": 3.5, "max": 5.5 },
+    "validation": {
+      "minFileSize": 50,
+      "note": "A .whfmt file is a JSON document — it starts with '{' (0x7B) or a UTF-8 BOM (0xEF 0xBB 0xBF) followed by '{'. Detection relies primarily on the file extension. The JSON must contain at least 'formatName' and 'extensions' properties to be a valid .whfmt."
+    }
+  },
+  "variables": {
+    "formatName": "",
+    "version": "",
+    "category": "",
+    "extensionCount": 0,
+    "blockCount": 0,
+    "hasDetection": false,
+    "hasBlocks": false,
+    "hasVariables": false,
+    "hasAssertions": false,
+    "hasForensic": false,
+    "hasNavigation": false,
+    "hasInspector": false,
+    "hasAiHints": false,
+    "hasSyntaxDefinition": false,
+    "preferredEditor": "",
+    "diffMode": ""
+  },
+  "blocks": [
+    {
+      "type": "group",
+      "name": "Root Object",
+      "description": "Top-level JSON object. All .whfmt files are JSON documents conforming to whfmt.schema.json.",
+      "color": "#6C5CE7",
+      "opacity": 0.2,
+      "children": [
+        {
+          "type": "field",
+          "name": "formatName",
+          "description": "Human-readable name displayed in the UI and used for format identification. Required.",
+          "color": "#FF6B6B",
+          "opacity": 0.4,
+          "valueType": "string"
+        },
+        {
+          "type": "field",
+          "name": "version",
+          "description": "Semantic version of this format definition (not the binary format it describes). Monotonically increasing — never regress.",
+          "color": "#FFA07A",
+          "opacity": 0.35,
+          "valueType": "string"
+        },
+        {
+          "type": "field",
+          "name": "extensions",
+          "description": "Array of file extensions (including leading dot) that this definition matches. Used by EmbeddedFormatCatalog for lookup.",
+          "color": "#4ECDC4",
+          "opacity": 0.35,
+          "valueType": "string[]"
+        },
+        {
+          "type": "field",
+          "name": "description",
+          "description": "Detailed description of the binary format — its structure, byte layout, endianness, and any other relevant technical information.",
+          "color": "#FFE66D",
+          "opacity": 0.3,
+          "valueType": "string"
+        },
+        {
+          "type": "field",
+          "name": "category",
+          "description": "Organizational category (e.g., Images, Audio, Archives, Programming, Data, System, 3D, CAD, etc.).",
+          "color": "#95E1D3",
+          "opacity": 0.3,
+          "valueType": "string"
+        },
+        {
+          "type": "field",
+          "name": "preferredEditor",
+          "description": "Editor hint for the EditorRegistry. Values: 'hex-editor' (default), 'code-editor', 'structure-editor', 'image-viewer', etc.",
+          "color": "#DDA0DD",
+          "opacity": 0.35,
+          "valueType": "string"
+        },
+        {
+          "type": "field",
+          "name": "diffMode",
+          "description": "Diff strategy: 'binary' for hex-level diffing, 'text' for line-based diffing.",
+          "color": "#87CEEB",
+          "opacity": 0.3,
+          "valueType": "string"
+        }
+      ]
+    },
+    {
+      "type": "group",
+      "name": "detection",
+      "description": "Magic-byte signature and heuristic detection rules. Used by FormatDetector to auto-identify files opened in the hex editor.",
+      "color": "#E74C3C",
+      "opacity": 0.25,
+      "children": [
+        {
+          "type": "field",
+          "name": "detection.signature",
+          "description": "Hex string of magic bytes (e.g., '89504E47' for PNG). Matched at detection.offset.",
+          "color": "#FF6B6B",
+          "opacity": 0.4,
+          "valueType": "string"
+        },
+        {
+          "type": "field",
+          "name": "detection.offset",
+          "description": "Byte offset where the signature starts (typically 0).",
+          "color": "#FFA07A",
+          "opacity": 0.35,
+          "valueType": "uint32"
+        },
+        {
+          "type": "field",
+          "name": "detection.Strength",
+          "description": "Confidence level: 'Strong' (unique magic), 'Moderate' (shared magic), 'Weak' (heuristic).",
+          "color": "#FFE66D",
+          "opacity": 0.35,
+          "valueType": "string"
+        }
+      ]
+    },
+    {
+      "type": "group",
+      "name": "blocks[]",
+      "description": "Array of block definitions that describe the binary layout. Each block has a type (signature, field, group, computed, metadata, etc.), offset, length, color, and description.",
+      "color": "#2ECC71",
+      "opacity": 0.25,
+      "children": [
+        {
+          "type": "field",
+          "name": "block.type",
+          "description": "Block type: 'signature', 'field', 'group', 'computeFromVariables', 'metadata', 'reserved', 'padding', 'array', 'conditional', 'switch', 'bitfield'.",
+          "color": "#4ECDC4",
+          "opacity": 0.4,
+          "valueType": "string"
+        },
+        {
+          "type": "field",
+          "name": "block.name",
+          "description": "Display name for the block shown in the hex editor overlay and the StructureEditor tree.",
+          "color": "#95E1D3",
+          "opacity": 0.35,
+          "valueType": "string"
+        },
+        {
+          "type": "field",
+          "name": "block.offset",
+          "description": "Byte offset from file start (or parent group start for nested blocks).",
+          "color": "#87CEEB",
+          "opacity": 0.35,
+          "valueType": "uint32"
+        },
+        {
+          "type": "field",
+          "name": "block.length",
+          "description": "Length in bytes. Can be a number or a variable expression (e.g., 'var:headerSize').",
+          "color": "#DDA0DD",
+          "opacity": 0.35,
+          "valueType": "uint32"
+        },
+        {
+          "type": "field",
+          "name": "block.color",
+          "description": "Hex color for the overlay highlight in the hex editor (e.g., '#FF6B6B').",
+          "color": "#FFB6C1",
+          "opacity": 0.35,
+          "valueType": "string"
+        },
+        {
+          "type": "field",
+          "name": "block.valueType",
+          "description": "Data type: 'uint8', 'uint16', 'uint32', 'uint64', 'int8'...'int64', 'float32', 'float64', 'ascii', 'utf8', 'utf16', 'hex', 'flags', 'string[]', etc.",
+          "color": "#98D8C8",
+          "opacity": 0.35,
+          "valueType": "string"
+        }
+      ]
+    },
+    {
+      "type": "group",
+      "name": "variables",
+      "description": "Key/value store for parsed values. Blocks with 'storeAs' write here; expressions with 'var:' and 'calc:' read from here.",
+      "color": "#F39C12",
+      "opacity": 0.25
+    },
+    {
+      "type": "group",
+      "name": "assertions[]",
+      "description": "Post-parse validation rules. Each assertion has an expression evaluated against variables, a severity, and a failure message.",
+      "color": "#E74C3C",
+      "opacity": 0.2
+    },
+    {
+      "type": "group",
+      "name": "forensic",
+      "description": "Security analysis metadata — risk level, suspicious patterns, and known exploit vectors for the format.",
+      "color": "#8E44AD",
+      "opacity": 0.2
+    },
+    {
+      "type": "group",
+      "name": "navigation",
+      "description": "Bookmark definitions for quick-jump navigation in the hex editor.",
+      "color": "#3498DB",
+      "opacity": 0.2
+    },
+    {
+      "type": "group",
+      "name": "inspector",
+      "description": "Inspector panel layout — field groupings, badge variable, and primary display field.",
+      "color": "#1ABC9C",
+      "opacity": 0.2
+    },
+    {
+      "type": "group",
+      "name": "aiHints",
+      "description": "Context hints for AI-assisted analysis — analysis context, known vulnerabilities, and suggested inspections.",
+      "color": "#9B59B6",
+      "opacity": 0.2
+    },
+    {
+      "type": "group",
+      "name": "syntaxDefinition",
+      "description": "Optional syntax highlighting definition for text-based formats opened in the CodeEditor. Includes tokenizer rules, formatting rules, and comment styles.",
+      "color": "#E67E22",
+      "opacity": 0.2
+    },
+    {
+      "type": "group",
+      "name": "QualityMetrics",
+      "description": "Self-assessment metadata — completeness score, documentation level, block count, validation rule count, and last update date.",
+      "color": "#16A085",
+      "opacity": 0.2
+    }
+  ],
+  "assertions": [
+    {
+      "name": "formatName required",
+      "expression": "formatName != ''",
+      "severity": "error",
+      "message": "Every .whfmt file must have a non-empty 'formatName'"
+    },
+    {
+      "name": "extensions required",
+      "expression": "extensionCount > 0",
+      "severity": "error",
+      "message": "Every .whfmt file must declare at least one file extension"
+    },
+    {
+      "name": "version required",
+      "expression": "version != ''",
+      "severity": "warning",
+      "message": "A version string is recommended for change tracking"
+    },
+    {
+      "name": "has detection or extension-only",
+      "expression": "hasDetection || extensionCount > 0",
+      "severity": "warning",
+      "message": "Format should have either detection rules or at least one extension for identification"
+    },
+    {
+      "name": "has blocks for binary formats",
+      "expression": "hasBlocks || diffMode == 'text'",
+      "severity": "warning",
+      "message": "Binary format definitions should declare at least one block for hex overlay rendering"
+    }
+  ],
+  "navigation": {
+    "bookmarks": [
+      {
+        "name": "Root Object",
+        "offset": 0,
+        "icon": "\uE943",
+        "color": "#6C5CE7"
+      }
+    ]
+  },
+  "inspector": {
+    "badge": "category",
+    "primaryField": "formatName",
+    "showQualityScore": true,
+    "groups": [
+      {
+        "title": "Identity",
+        "icon": "\uE946",
+        "fields": ["formatName", "version", "category", "diffMode", "preferredEditor"]
+      },
+      {
+        "title": "Structure",
+        "icon": "\uE8A5",
+        "fields": ["extensionCount", "blockCount", "hasDetection", "hasBlocks", "hasVariables", "hasAssertions"]
+      },
+      {
+        "title": "Richness",
+        "icon": "\uE82D",
+        "fields": ["hasForensic", "hasNavigation", "hasInspector", "hasAiHints", "hasSyntaxDefinition"]
+      }
+    ]
+  },
+  "exportTemplates": [
+    {
+      "name": "WHFMT Summary (JSON)",
+      "format": "json",
+      "fields": ["formatName", "version", "category", "extensionCount", "blockCount", "hasDetection"]
+    }
+  ],
+  "forensic": {
+    "category": "data",
+    "riskLevel": "low",
+    "suspiciousPatterns": [
+      {
+        "name": "Missing formatName",
+        "condition": "formatName == ''",
+        "severity": "error",
+        "description": "A .whfmt file without a formatName is invalid and will be rejected by the format catalog."
+      },
+      {
+        "name": "No extensions declared",
+        "condition": "extensionCount == 0",
+        "severity": "error",
+        "description": "Without extensions, the format cannot be matched to any file — it becomes an orphaned definition."
+      },
+      {
+        "name": "Very large block count",
+        "condition": "blockCount > 200",
+        "severity": "warning",
+        "description": "Definitions with 200+ blocks may cause rendering slowdown in the hex editor overlay."
+      }
+    ],
+    "knownExploitVectors": [
+      "JSON injection: malicious 'expression' fields in assertions or computeFromVariables could exploit naive eval() — WPFHexaEditor uses a sandboxed expression parser",
+      "Path traversal: 'formatName' displayed as-is — ensure no XAML injection in the UI binding",
+      "Denial-of-service: deeply nested 'children' in block groups could cause stack overflow in recursive parsers"
+    ]
+  },
+  "aiHints": {
+    "analysisContext": "A .whfmt file is a JSON document conforming to whfmt.schema.json. It describes a binary or text file format for the WPFHexaEditor IDE. Root properties: formatName (required string), extensions (required string[]), version, description, category, preferredEditor, diffMode, detection (object with signature/offset/Strength), blocks (array of typed block definitions), variables (key-value store), assertions (validation rules), forensic (security metadata), navigation (bookmarks), inspector (UI panel layout), aiHints (AI context), syntaxDefinition (tokenizer for text formats), QualityMetrics (self-assessment). This is the meta-format — the .whfmt that describes .whfmt files.",
+    "suggestedInspections": [
+      "Verify 'formatName' and 'extensions' are present and non-empty",
+      "Check that all blocks with 'storeAs' reference valid keys in 'variables'",
+      "Validate assertion expressions against declared variables",
+      "Confirm detection.signature is valid hex (even number of hex digits)",
+      "Check QualityMetrics.CompletenessScore is reasonable for the number of sections defined"
+    ]
+  },
+  "software": [
+    "WPFHexaEditor (native)",
+    "Visual Studio Code (with whfmt.schema.json)",
+    "JetBrains Rider (with whfmt.schema.json)",
+    "Any JSON editor"
+  ],
+  "formatRelationships": {
+    "category": "Data",
+    "extensions": [".whfmt"],
+    "note": "The .whfmt format is proprietary to WPFHexaEditor. It is a superset of JSON with domain-specific semantics. Files can be edited in the StructureEditor (visual) or any JSON-aware code editor."
+  },
+  "MimeTypes": [
+    "application/json",
+    "application/vnd.wpfhexaeditor.format+json"
+  ],
+  "UseCases": [
+    "Define binary file format overlays for the WPFHexaEditor hex editor",
+    "Provide detection signatures for automatic format identification",
+    "Document binary format structure for analysis and forensics",
+    "Generate C struct / Python bytes export templates from format layouts",
+    "Provide syntax highlighting definitions for text-based formats"
+  ],
+  "QualityMetrics": {
+    "CompletenessScore": 92,
+    "DocumentationLevel": "detailed",
+    "BlocksDefined": 12,
+    "ValidationRules": 5,
+    "LastUpdated": "2026-04-14",
+    "PriorityFormat": true,
+    "AutoRefined": false
+  },
+  "TechnicalDetails": {
+    "TextFormat": true,
+    "Encoding": "UTF-8",
+    "Schema": "whfmt.schema.json",
+    "Compression": "none",
+    "HasHeader": false,
+    "SelfReferential": true
+  }
+}

--- a/Sources/Core/WpfHexEditor.Core.Definitions/FormatDefinitions/Database/LEVELDB_SST.whfmt
+++ b/Sources/Core/WpfHexEditor.Core.Definitions/FormatDefinitions/Database/LEVELDB_SST.whfmt
@@ -1,0 +1,185 @@
+{
+  "diffMode": "binary",
+  "formatName": "LevelDB/RocksDB SSTable",
+  "version": "1.0",
+  "extensions": [".ldb", ".sst"],
+  "description": "LevelDB .ldb and RocksDB .sst files are Sorted String Table (SSTable) files — immutable, sorted key-value stores used as the on-disk format for LevelDB (Google, 2011) and RocksDB (Facebook, 2012). An SSTable contains data blocks (key-value pairs sorted by key), a filter meta block (optional Bloom filter for fast key lookups), a stats meta block, a metaindex block, an index block, and a fixed-size footer. Each data block ends with a restart array and a CRC32 checksum. The footer (48 bytes at EOF) contains the metaindex block handle, index block handle, optional checksum type, and an 8-byte magic number: LevelDB=0x8428752488808FB57 (bytes 57 FB 80 8B 24 75 48 84) or RocksDB=0x8428752488808FB57 variant (F7 CF F4 85 B7 41 E2 88). Used by: Google Chrome (IndexedDB, local storage), Electron apps, VS Code extensions, Node.js (leveldown), TensorFlow serving, Apache Cassandra (SSTable variant).",
+  "category": "Database",
+  "author": "WPFHexaEditor Team",
+  "preferredEditor": "hex-editor",
+  "references": {
+    "specifications": [
+      "LevelDB SSTable format — Google/leveldb GitHub documentation",
+      "RocksDB SST file format — Facebook/rocksdb wiki"
+    ],
+    "WebLinks": [
+      "https://github.com/google/leveldb/blob/main/doc/table_format.md",
+      "https://github.com/facebook/rocksdb/wiki/Rocksdb-BlockBasedTable-Format",
+      "https://github.com/google/leveldb/blob/main/doc/impl.md"
+    ]
+  },
+  "detection": {
+    "signatures": [
+      { "value": "57FB808B24752484", "offset": 0, "label": "LevelDB footer magic at offset 0 (rare — only if file IS the footer)", "weight": 0.1 },
+      { "value": "F7CFF485B741E288", "offset": 0, "label": "RocksDB footer magic at offset 0 (rare)", "weight": 0.1 }
+    ],
+    "matchMode": "any",
+    "MinimumScore": 0.1,
+    "required": false,
+    "Strength": "Weak",
+    "EntropyHint": { "min": 2.0, "max": 7.5 },
+    "validation": {
+      "minFileSize": 48,
+      "maxSignatureOffset": 0,
+      "note": "LevelDB/RocksDB SSTable files have no magic at offset 0. True identification requires reading the last 8 bytes (footer magic): LevelDB=57 FB 80 8B 24 75 48 84, RocksDB=F7 CF F4 85 B7 41 E2 88. Detection is primarily extension-based (.ldb, .sst)."
+    }
+  },
+  "variables": {
+    "sstFirstByte": 0,
+    "sstBlockType": 0
+  },
+  "blocks": [
+    {
+      "type": "field",
+      "name": "First Data Block Byte",
+      "offset": 0,
+      "length": 1,
+      "color": "#4ECDC4",
+      "opacity": 0.35,
+      "description": "First byte of the SSTable file — start of the first data block. LevelDB/RocksDB SSTables begin with data blocks containing sorted key-value pairs. Each data block entry: shared_key_length(varint32) + unshared_key_length(varint32) + value_length(varint32) + key_delta(bytes) + value(bytes). The first restart point shared_length is always 0.",
+      "storeAs": "sstFirstByte",
+      "valueType": "uint8"
+    },
+    {
+      "type": "field",
+      "name": "Second Byte",
+      "offset": 1,
+      "length": 1,
+      "color": "#4ECDC4",
+      "opacity": 0.25,
+      "description": "Second byte of the SSTable — part of the first varint-encoded key length in the first data block entry. VarInt encoding: bit 7 of each byte is continuation flag (1=more bytes follow). Bits 0-6 are 7-bit data chunks assembled LSB-first.",
+      "storeAs": "sstBlockType",
+      "valueType": "uint8"
+    },
+    {
+      "type": "metadata",
+      "name": "SSTable Start",
+      "variable": "sstFirstByte",
+      "description": "First byte of SSTable data block — varint-encoded key entry"
+    },
+    {
+      "type": "metadata",
+      "name": "SSTable Format Note",
+      "variable": "sstBlockType",
+      "description": "Footer magic (last 8 bytes): LevelDB=57 FB 80 8B 24 75 48 84 | RocksDB=F7 CF F4 85 B7 41 E2 88"
+    }
+  ],
+  "assertions": [
+    {
+      "name": "Minimum SSTable size",
+      "expression": "true",
+      "severity": "info",
+      "message": "LevelDB SSTable minimum size is 48 bytes (footer only). Typical .ldb/.sst files range from 2MB to 64MB. Verify file size is at least 48 bytes."
+    },
+    {
+      "name": "LevelDB footer magic",
+      "expression": "true",
+      "severity": "info",
+      "message": "True validation requires reading last 8 bytes: LevelDB magic=57FB808B24752484, RocksDB magic=F7CFF485B741E288. Extension .ldb = LevelDB, .sst = RocksDB or LevelDB depending on version."
+    },
+    {
+      "name": "Block compression type",
+      "expression": "sstFirstByte <= 4",
+      "severity": "warning",
+      "message": "First byte > 4 may indicate unsupported block compression. LevelDB compression types: 0x00=None, 0x01=Snappy, 0x02=Zlib, 0x03=BZip2, 0x04=LZ4."
+    }
+  ],
+  "navigation": {
+    "bookmarks": [
+      { "name": "SSTable Start", "offset": 0, "icon": "\uE8D3", "color": "#4ECDC4" }
+    ]
+  },
+  "inspector": {
+    "badge": "sstFirstByte",
+    "primaryField": "sstFirstByte",
+    "showQualityScore": true,
+    "groups": [
+      {
+        "title": "SSTable Header",
+        "icon": "\uE8D3",
+        "fields": ["sstFirstByte", "sstBlockType"]
+      }
+    ]
+  },
+  "exportTemplates": [
+    {
+      "name": "SSTable Info (JSON)",
+      "format": "json",
+      "fields": ["sstFirstByte", "sstBlockType"]
+    },
+    {
+      "name": "SSTable Summary (Text)",
+      "format": "text",
+      "fields": ["sstFirstByte"]
+    }
+  ],
+  "forensic": {
+    "category": "database",
+    "riskLevel": "medium",
+    "suspiciousPatterns": [
+      {
+        "name": "Chrome/Electron database artifact",
+        "condition": "true",
+        "severity": "info",
+        "description": "LevelDB .ldb files in Chrome/Electron app profiles contain browsing history, IndexedDB storage, localStorage, and extension data. Common forensic artifact locations: %APPDATA%\\Google\\Chrome\\User Data\\Default\\IndexedDB\\, %APPDATA%\\Microsoft\\Teams\\, VS Code workspaceStorage."
+      }
+    ]
+  },
+  "aiHints": {
+    "analysisContext": "LevelDB/RocksDB SSTable: no magic at offset 0. Magic at last 8 bytes: LevelDB=57FB808B24752484, RocksDB=F7CFF485B741E288. File layout: [data blocks] + [filter meta block] + [stats block] + [metaindex block] + [index block] + [footer=48B]. Footer: metaindex_handle(varint64x2) + index_handle(varint64x2) + padding + magic(8B). Block entry: shared_len(varint) + unshared_len(varint) + value_len(varint) + key(bytes) + value(bytes). Block trailer: restart_offsets[](uint32 LE) + num_restarts(uint32 LE) + compression_type(1B) + crc32(4B). Tools: ldb (LevelDB CLI), sst_dump (RocksDB CLI), leveldb-viewer. Used by Chrome, Electron, VS Code.",
+    "suggestedInspections": [
+      "Read last 8 bytes to identify LevelDB (57 FB 80 8B 24 75 48 84) vs RocksDB (F7 CF F4 85 B7 41 E2 88)",
+      "Read last 48 bytes (footer): first two varint pairs are metaindex_handle and index_handle offsets",
+      "Forensics: Chrome .ldb files contain serialized JS objects — search for UTF-16 strings at block boundaries",
+      "Block entries start at offset 0 — first entry has shared_length=0 so first 3 varints = 0, key_len, value_len",
+      "Use ldb CLI: `ldb scan --db=<directory>` to enumerate key-value pairs without hex parsing"
+    ]
+  },
+  "software": [
+    "ldb (Google LevelDB command-line tool — scan, dump, repair)",
+    "sst_dump (RocksDB SSTable inspector — prints all keys/values)",
+    "leveldb-viewer (GUI tool for Chrome LevelDB databases)",
+    "Chromium DevTools (reads LevelDB IndexedDB directly)"
+  ],
+  "formatRelationships": {
+    "category": "Database",
+    "extensions": [".ldb", ".sst"],
+    "relatedFormats": ["SQLITE", "LEVELDB_LOG"],
+    "note": ".ldb is the standard LevelDB SSTable extension (Google, 2011). .sst is used by RocksDB (Facebook, 2012, based on LevelDB). Both formats are functionally identical at the SSTable level but differ in footer magic and supported compression codecs. LevelDB supports Snappy only; RocksDB adds Zlib, BZip2, LZ4, Zstd."
+  },
+  "MimeTypes": ["application/octet-stream"],
+  "UseCases": [
+    "Forensic extraction of Chrome browser history and IndexedDB data",
+    "VS Code extension storage and workspace state analysis",
+    "RocksDB compaction monitoring and SST file inspection",
+    "Electron app local storage forensics (.ldb in app profiles)"
+  ],
+  "QualityMetrics": {
+    "CompletenessScore": 72,
+    "DocumentationLevel": "detailed",
+    "BlocksDefined": 4,
+    "ValidationRules": 3,
+    "LastUpdated": "2026-04-14",
+    "PriorityFormat": false,
+    "AutoRefined": false
+  },
+  "TechnicalDetails": {
+    "Format": "Sorted String Table (SSTable) — immutable sorted key-value file",
+    "LevelDB_Magic": "57 FB 80 8B 24 75 48 84 (last 8 bytes of file)",
+    "RocksDB_Magic": "F7 CF F4 85 B7 41 E2 88 (last 8 bytes of file)",
+    "Footer": "48 bytes at EOF: metaindex_handle(varint) + index_handle(varint) + padding + magic(8B)",
+    "Blocks": "Data blocks, filter block (Bloom), stats block, metaindex block, index block",
+    "Encoding": "Keys sorted lexicographically; varint32/varint64 for lengths and offsets",
+    "Compression": "Per-block: 0x00=None, 0x01=Snappy (LevelDB default), 0x04=LZ4 (RocksDB)"
+  }
+}

--- a/Sources/Core/WpfHexEditor.Core.Definitions/FormatDefinitions/Disk/APFS.whfmt
+++ b/Sources/Core/WpfHexEditor.Core.Definitions/FormatDefinitions/Disk/APFS.whfmt
@@ -1,0 +1,429 @@
+{
+  "diffMode": "binary",
+  "formatName": "Apple File System (APFS)",
+  "version": "1.0",
+  "extensions": [],
+  "description": "Apple File System container superblock with copy-on-write B-tree structure and per-volume encryption",
+  "category": "Disk",
+  "author": "WPFHexaEditor Team",
+  "preferredEditor": "hex-editor",
+  "references": {
+    "specifications": [
+      "Apple File System Reference (developer.apple.com)",
+      "APFS Container and Volume Superblock Specification",
+      "Apple APFS Filesystem Internals"
+    ],
+    "WebLinks": [
+      "https://en.wikipedia.org/wiki/Apple_File_System",
+      "https://developer.apple.com/support/downloads/Apple-File-System-Reference.pdf",
+      "https://github.com/sgan81/apfs-fuse",
+      "https://blog.cugu.eu/post/apfs/"
+    ]
+  },
+  "detection": {
+    "required": true,
+    "validation": {
+      "minFileSize": 104,
+      "maxSignatureOffset": 36
+    },
+    "signatures": [
+      {
+        "value": "4E585342",
+        "offset": 32,
+        "label": "'NXSB' — APFS Container Superblock magic at offset 32",
+        "weight": 1.0
+      }
+    ],
+    "matchMode": "any",
+    "MinimumScore": 1.0,
+    "Strength": "Strong",
+    "EntropyHint": {
+      "min": 1.0,
+      "max": 7.0
+    }
+  },
+  "variables": {
+    "currentOffset": 0,
+    "objChecksum": 0,
+    "objOid": 0,
+    "objXid": 0,
+    "objType": 0,
+    "objSubtype": 0,
+    "nxMagic": 0,
+    "nxBlockSize": 0,
+    "nxBlockCount": 0,
+    "nxFeatures": 0,
+    "nxReadonlyFeatures": 0,
+    "nxIncompatFeatures": 0,
+    "nxUuid": 0,
+    "nxNextOid": 0,
+    "nxNextXid": 0
+  },
+  "blocks": [
+    {
+      "type": "field",
+      "name": "Object Checksum",
+      "offset": 0,
+      "length": 8,
+      "color": "#636E72",
+      "opacity": 0.3,
+      "description": "Fletcher-64 checksum of the entire block",
+      "storeAs": "objChecksum",
+      "valueType": "uint64"
+    },
+    {
+      "type": "field",
+      "name": "Object Identifier",
+      "offset": 8,
+      "length": 8,
+      "color": "#B2BEC3",
+      "opacity": 0.3,
+      "description": "Unique object identifier within the container",
+      "storeAs": "objOid",
+      "valueType": "uint64"
+    },
+    {
+      "type": "field",
+      "name": "Transaction Identifier",
+      "offset": 16,
+      "length": 8,
+      "color": "#DFE6E9",
+      "opacity": 0.3,
+      "description": "Transaction identifier (monotonically increasing)",
+      "storeAs": "objXid",
+      "valueType": "uint64"
+    },
+    {
+      "type": "field",
+      "name": "Object Type",
+      "offset": 24,
+      "length": 4,
+      "color": "#4ECDC4",
+      "opacity": 0.3,
+      "description": "Object type (0x01 = NX_SUPERBLOCK)",
+      "storeAs": "objType",
+      "valueType": "uint32",
+      "valueMap": {
+        "1": "NX_SUPERBLOCK (Container Superblock)"
+      }
+    },
+    {
+      "type": "field",
+      "name": "Object Subtype",
+      "offset": 28,
+      "length": 4,
+      "color": "#95E1D3",
+      "opacity": 0.3,
+      "description": "Object subtype (0 for container superblock)",
+      "storeAs": "objSubtype",
+      "valueType": "uint32"
+    },
+    {
+      "type": "signature",
+      "name": "APFS Magic",
+      "offset": 32,
+      "length": 4,
+      "color": "#FF6B6B",
+      "opacity": 0.4,
+      "description": "'NXSB' magic identifying this as an APFS Container Superblock",
+      "storeAs": "nxMagic",
+      "valueType": "ascii"
+    },
+    {
+      "type": "field",
+      "name": "Block Size",
+      "offset": 36,
+      "length": 4,
+      "color": "#FFD93D",
+      "opacity": 0.3,
+      "description": "Container block size in bytes (typically 4096)",
+      "storeAs": "nxBlockSize",
+      "valueType": "uint32"
+    },
+    {
+      "type": "field",
+      "name": "Block Count",
+      "offset": 40,
+      "length": 8,
+      "color": "#6C5CE7",
+      "opacity": 0.3,
+      "description": "Total number of blocks in the container",
+      "storeAs": "nxBlockCount",
+      "valueType": "uint64"
+    },
+    {
+      "type": "field",
+      "name": "Features",
+      "offset": 48,
+      "length": 8,
+      "color": "#E17055",
+      "opacity": 0.3,
+      "description": "Container feature flags",
+      "storeAs": "nxFeatures",
+      "valueType": "uint64"
+    },
+    {
+      "type": "field",
+      "name": "Read-Only Compatible Features",
+      "offset": 56,
+      "length": 8,
+      "color": "#00B894",
+      "opacity": 0.3,
+      "description": "Read-only compatible feature flags",
+      "storeAs": "nxReadonlyFeatures",
+      "valueType": "uint64"
+    },
+    {
+      "type": "field",
+      "name": "Incompatible Features",
+      "offset": 64,
+      "length": 8,
+      "color": "#0984E3",
+      "opacity": 0.3,
+      "description": "Incompatible feature flags (bit0=v1, bit1=fusion, bit8=sealed volumes)",
+      "storeAs": "nxIncompatFeatures",
+      "valueType": "uint64"
+    },
+    {
+      "type": "field",
+      "name": "Container UUID",
+      "offset": 72,
+      "length": 16,
+      "color": "#FDCB6E",
+      "opacity": 0.3,
+      "description": "Universally unique identifier for this APFS container",
+      "storeAs": "nxUuid",
+      "valueType": "bytes"
+    },
+    {
+      "type": "field",
+      "name": "Next Object Identifier",
+      "offset": 88,
+      "length": 8,
+      "color": "#E84393",
+      "opacity": 0.3,
+      "description": "Next object identifier to be allocated",
+      "storeAs": "nxNextOid",
+      "valueType": "uint64"
+    },
+    {
+      "type": "field",
+      "name": "Next Transaction Identifier",
+      "offset": 96,
+      "length": 8,
+      "color": "#A29BFE",
+      "opacity": 0.3,
+      "description": "Next transaction identifier to be assigned",
+      "storeAs": "nxNextXid",
+      "valueType": "uint64"
+    }
+  ],
+  "software": [
+    "diskutil (macOS)",
+    "apfs-fuse (Linux)",
+    "Paragon APFS for Windows"
+  ],
+  "formatRelationships": {
+    "category": "Disk",
+    "extensions": [],
+    "relatedFormats": [
+      "HFS+",
+      "EXT4",
+      "BTRFS",
+      "ZFS"
+    ]
+  },
+  "MimeTypes": [
+    "application/octet-stream"
+  ],
+  "Software": [
+    "diskutil (macOS)",
+    "apfs-fuse (Linux)",
+    "Paragon APFS for Windows",
+    "iBoot / IPSW restore tools",
+    "The Sleuth Kit (experimental APFS support)",
+    "BlackBag BlackLight (forensics)",
+    "Reincubate iPhone Backup Extractor"
+  ],
+  "UseCases": [
+    "macOS and iOS primary filesystem analysis",
+    "Apple device forensic imaging and examination",
+    "APFS snapshot enumeration and timeline reconstruction",
+    "FileVault encrypted volume investigation",
+    "Fusion Drive tiering analysis (SSD+HDD)",
+    "iOS backup and IPSW firmware inspection"
+  ],
+  "QualityMetrics": {
+    "CompletenessScore": 90,
+    "DocumentationLevel": "detailed",
+    "BlocksDefined": 14,
+    "ValidationRules": 4,
+    "LastUpdated": "2026-04-14",
+    "PriorityFormat": true,
+    "AutoRefined": false
+  },
+  "forensic": {
+    "category": "disk",
+    "riskLevel": "medium",
+    "suspiciousPatterns": [
+      {
+        "name": "FileVault encryption enabled",
+        "description": "Container may use per-volume encryption (FileVault), preventing direct content inspection",
+        "condition": "nxFeatures > 0"
+      },
+      {
+        "name": "Sealed volume detected",
+        "description": "Incompatible features bit 8 set, indicating a sealed (signed) system volume",
+        "condition": "nxIncompatFeatures > 0"
+      }
+    ]
+  },
+  "aiHints": {
+    "analysisContext": "Apple File System container superblock with copy-on-write B-tree, per-volume encryption, and snapshot support",
+    "suggestedInspections": [
+      "Verify 'NXSB' magic at offset 32 and object type field for container superblock identity",
+      "Validate Fletcher-64 checksum in the object header against the computed block checksum",
+      "Check block size is a valid power of 2 (typically 4096) and block count is non-zero",
+      "Inspect incompatible feature flags for Fusion Drive and sealed volume indicators",
+      "Examine container UUID for cross-referencing with volume superblocks",
+      "Analyze transaction identifier sequence for timeline reconstruction"
+    ]
+  },
+  "navigation": {
+    "bookmarks": [
+      {
+        "name": "Object Header",
+        "offsetVar": "currentOffset",
+        "icon": "header"
+      },
+      {
+        "name": "NXSB Magic",
+        "offset": 32,
+        "icon": "signature"
+      },
+      {
+        "name": "Container UUID",
+        "offset": 72,
+        "icon": "id"
+      }
+    ]
+  },
+  "TechnicalDetails": {
+    "endianness": "little",
+    "objectHeader": "All objects share a 32-byte header: checksum(8B) + oid(8B) + xid(8B) + type(4B) + subtype(4B)",
+    "checksumAlgorithm": "Fletcher-64 over the entire block (with checksum field zeroed during computation)",
+    "dataStructure": "Copy-on-write B-tree filesystem with container and volume superblocks",
+    "containerModel": "Container holds one or more volumes with shared space pool",
+    "encryption": "Per-file or per-volume encryption; FileVault uses per-volume keys",
+    "snapshots": "Atomic point-in-time snapshots via transaction identifier fencing",
+    "clones": "Instant file cloning via shared data extents with reference counting",
+    "fusionDrive": "SSD+HDD tiering managed at the container level",
+    "sealedVolumes": "macOS signed system volumes (Big Sur+) with cryptographic integrity"
+  },
+  "inspector": {
+    "badge": "nxMagic",
+    "primaryField": "nxBlockSize",
+    "showQualityScore": true,
+    "groups": [
+      {
+        "title": "Object Header",
+        "icon": "header",
+        "fields": [
+          "objChecksum",
+          "objOid",
+          "objXid",
+          "objType",
+          "objSubtype"
+        ]
+      },
+      {
+        "title": "Container Superblock",
+        "icon": "disk",
+        "fields": [
+          "nxMagic",
+          "nxBlockSize",
+          "nxBlockCount",
+          "nxUuid"
+        ]
+      },
+      {
+        "title": "Feature Flags",
+        "icon": "flag",
+        "fields": [
+          "nxFeatures",
+          "nxReadonlyFeatures",
+          "nxIncompatFeatures"
+        ]
+      },
+      {
+        "title": "Allocation State",
+        "icon": "counter",
+        "fields": [
+          "nxNextOid",
+          "nxNextXid"
+        ]
+      }
+    ]
+  },
+  "exportTemplates": [
+    {
+      "name": "APFS Container Header (JSON)",
+      "format": "json",
+      "fields": [
+        "objChecksum",
+        "objOid",
+        "objXid",
+        "objType",
+        "nxMagic",
+        "nxBlockSize",
+        "nxBlockCount",
+        "nxUuid",
+        "nxFeatures",
+        "nxIncompatFeatures"
+      ]
+    },
+    {
+      "name": "APFS Summary (CSV)",
+      "format": "csv",
+      "fields": [
+        "nxBlockSize",
+        "nxBlockCount",
+        "nxFeatures",
+        "nxIncompatFeatures",
+        "nxNextOid",
+        "nxNextXid"
+      ]
+    }
+  ],
+  "assertions": [
+    {
+      "name": "NXSB magic valid",
+      "expression": "nxMagic == 'NXSB'",
+      "severity": "error",
+      "message": "APFS container superblock magic must be 'NXSB' at offset 32"
+    },
+    {
+      "name": "object type is container superblock",
+      "expression": "objType == 1",
+      "severity": "error",
+      "message": "Object type must be 1 (NX_SUPERBLOCK) for container superblock"
+    },
+    {
+      "name": "block size is power of 2",
+      "expression": "nxBlockSize >= 512 && nxBlockSize <= 65536",
+      "severity": "error",
+      "message": "Block size must be a power of 2 between 512 and 65536 bytes"
+    },
+    {
+      "name": "block count non-zero",
+      "expression": "nxBlockCount > 0",
+      "severity": "error",
+      "message": "Container block count must be greater than zero"
+    }
+  ],
+  "functions": {
+    "readUInt32LE": "Read little-endian 32-bit fields",
+    "readUInt64LE": "Read little-endian 64-bit fields",
+    "readBytes": "Read raw byte arrays (UUID, checksum)"
+  }
+}

--- a/Sources/Core/WpfHexEditor.Core.Definitions/FormatDefinitions/Disk/QCOW2.whfmt
+++ b/Sources/Core/WpfHexEditor.Core.Definitions/FormatDefinitions/Disk/QCOW2.whfmt
@@ -1,0 +1,450 @@
+{
+  "diffMode": "binary",
+  "formatName": "QCOW2 Virtual Disk",
+  "version": "1.0",
+  "extensions": [
+    ".qcow2",
+    ".qcow"
+  ],
+  "description": "QEMU Copy-On-Write v2 virtual disk image format with snapshot and encryption support",
+  "category": "Disk",
+  "author": "WPFHexaEditor Team",
+  "preferredEditor": "hex-editor",
+  "references": {
+    "specifications": [
+      "QCOW2 Image Format Specification",
+      "QEMU Block Layer Documentation",
+      "QCOW2 v3 Extended Header Format"
+    ],
+    "WebLinks": [
+      "https://en.wikipedia.org/wiki/Qcow",
+      "https://github.com/qemu/qemu/blob/master/docs/interop/qcow2.txt",
+      "https://formats.kaitai.io/qcow2/",
+      "https://www.qemu.org/docs/master/system/images.html"
+    ]
+  },
+  "detection": {
+    "required": true,
+    "validation": {
+      "minFileSize": 72,
+      "maxSignatureOffset": 0
+    },
+    "signatures": [
+      {
+        "value": "514649FB",
+        "offset": 0,
+        "label": "'QFI\\xFB' — QCOW2 container magic at offset 0",
+        "weight": 1.0
+      }
+    ],
+    "matchMode": "any",
+    "MinimumScore": 1.0,
+    "Strength": "Strong",
+    "EntropyHint": {
+      "min": 1.0,
+      "max": 8.0
+    }
+  },
+  "variables": {
+    "currentOffset": 0,
+    "magic": 0,
+    "qcowVersion": 0,
+    "backingFileOffset": 0,
+    "backingFileSize": 0,
+    "clusterBits": 0,
+    "virtualSize": 0,
+    "cryptMethod": 0,
+    "l1Size": 0,
+    "l1TableOffset": 0,
+    "refcountTableOffset": 0,
+    "refcountTableClusters": 0,
+    "nbSnapshots": 0,
+    "snapshotsOffset": 0
+  },
+  "blocks": [
+    {
+      "type": "signature",
+      "name": "QCOW2 Magic",
+      "offset": 0,
+      "length": 4,
+      "color": "#FF6B6B",
+      "opacity": 0.4,
+      "description": "QFI\\xFB magic signature (0x514649FB)",
+      "storeAs": "magic",
+      "valueType": "uint32",
+      "endianness": "big"
+    },
+    {
+      "type": "field",
+      "name": "Version",
+      "offset": 4,
+      "length": 4,
+      "color": "#4ECDC4",
+      "opacity": 0.3,
+      "description": "QCOW format version (2 or 3)",
+      "storeAs": "qcowVersion",
+      "valueType": "uint32",
+      "endianness": "big",
+      "valueMap": {
+        "2": "QCOW2",
+        "3": "QCOW2 v3 (extended features)"
+      }
+    },
+    {
+      "type": "field",
+      "name": "Backing File Offset",
+      "offset": 8,
+      "length": 8,
+      "color": "#95E1D3",
+      "opacity": 0.3,
+      "description": "Offset to backing file name string (0 if no backing file)",
+      "storeAs": "backingFileOffset",
+      "valueType": "uint64",
+      "endianness": "big"
+    },
+    {
+      "type": "field",
+      "name": "Backing File Size",
+      "offset": 16,
+      "length": 4,
+      "color": "#A8E6CF",
+      "opacity": 0.3,
+      "description": "Length of the backing file name in bytes",
+      "storeAs": "backingFileSize",
+      "valueType": "uint32",
+      "endianness": "big"
+    },
+    {
+      "type": "field",
+      "name": "Cluster Bits",
+      "offset": 20,
+      "length": 4,
+      "color": "#FFD93D",
+      "opacity": 0.3,
+      "description": "Log2 of cluster size (typically 16 = 64KB clusters)",
+      "storeAs": "clusterBits",
+      "valueType": "uint32",
+      "endianness": "big"
+    },
+    {
+      "type": "field",
+      "name": "Virtual Size",
+      "offset": 24,
+      "length": 8,
+      "color": "#6C5CE7",
+      "opacity": 0.3,
+      "description": "Virtual disk size in bytes",
+      "storeAs": "virtualSize",
+      "valueType": "uint64",
+      "endianness": "big"
+    },
+    {
+      "type": "field",
+      "name": "Encryption Method",
+      "offset": 32,
+      "length": 4,
+      "color": "#E17055",
+      "opacity": 0.3,
+      "description": "Encryption method used for the image",
+      "storeAs": "cryptMethod",
+      "valueType": "uint32",
+      "endianness": "big",
+      "valueMap": {
+        "0": "None",
+        "1": "AES-128-CBC (deprecated)",
+        "2": "LUKS"
+      }
+    },
+    {
+      "type": "field",
+      "name": "L1 Table Size",
+      "offset": 36,
+      "length": 4,
+      "color": "#00B894",
+      "opacity": 0.3,
+      "description": "Number of entries in the active L1 table",
+      "storeAs": "l1Size",
+      "valueType": "uint32",
+      "endianness": "big"
+    },
+    {
+      "type": "field",
+      "name": "L1 Table Offset",
+      "offset": 40,
+      "length": 8,
+      "color": "#0984E3",
+      "opacity": 0.3,
+      "description": "Offset into the image file of the active L1 table",
+      "storeAs": "l1TableOffset",
+      "valueType": "uint64",
+      "endianness": "big"
+    },
+    {
+      "type": "field",
+      "name": "Refcount Table Offset",
+      "offset": 48,
+      "length": 8,
+      "color": "#FDCB6E",
+      "opacity": 0.3,
+      "description": "Offset into the image file of the refcount table",
+      "storeAs": "refcountTableOffset",
+      "valueType": "uint64",
+      "endianness": "big"
+    },
+    {
+      "type": "field",
+      "name": "Refcount Table Clusters",
+      "offset": 56,
+      "length": 4,
+      "color": "#E84393",
+      "opacity": 0.3,
+      "description": "Number of clusters occupied by the refcount table",
+      "storeAs": "refcountTableClusters",
+      "valueType": "uint32",
+      "endianness": "big"
+    },
+    {
+      "type": "field",
+      "name": "Number of Snapshots",
+      "offset": 60,
+      "length": 4,
+      "color": "#74B9FF",
+      "opacity": 0.3,
+      "description": "Number of snapshots contained in the image",
+      "storeAs": "nbSnapshots",
+      "valueType": "uint32",
+      "endianness": "big"
+    },
+    {
+      "type": "field",
+      "name": "Snapshots Offset",
+      "offset": 64,
+      "length": 8,
+      "color": "#A29BFE",
+      "opacity": 0.3,
+      "description": "Offset into the image file of the snapshot table",
+      "storeAs": "snapshotsOffset",
+      "valueType": "uint64",
+      "endianness": "big"
+    }
+  ],
+  "software": [
+    "QEMU (qemu-img)",
+    "libvirt",
+    "virt-manager"
+  ],
+  "formatRelationships": {
+    "category": "Disk",
+    "extensions": [
+      ".qcow2",
+      ".qcow"
+    ],
+    "relatedFormats": [
+      "VHD",
+      "VHDX",
+      "VMDK",
+      "VDI",
+      "RAW"
+    ]
+  },
+  "MimeTypes": [
+    "application/x-qemu-disk",
+    "application/octet-stream"
+  ],
+  "Software": [
+    "QEMU (qemu-img)",
+    "libvirt",
+    "virt-manager",
+    "VirtualBox (import)",
+    "guestfish (libguestfs)",
+    "nbdkit",
+    "qemu-nbd"
+  ],
+  "UseCases": [
+    "Virtual machine disk storage",
+    "Snapshot-based backup and rollback",
+    "Thin provisioning of virtual disks",
+    "Incremental disk image chains via backing files",
+    "Encrypted virtual disk images with LUKS",
+    "Forensic analysis of VM disk contents"
+  ],
+  "QualityMetrics": {
+    "CompletenessScore": 90,
+    "DocumentationLevel": "detailed",
+    "BlocksDefined": 13,
+    "ValidationRules": 5,
+    "LastUpdated": "2026-04-14",
+    "PriorityFormat": true,
+    "AutoRefined": false
+  },
+  "forensic": {
+    "category": "disk",
+    "riskLevel": "medium",
+    "suspiciousPatterns": [
+      {
+        "name": "Encrypted QCOW2 image",
+        "description": "Image uses AES or LUKS encryption, contents not directly inspectable",
+        "condition": "cryptMethod > 0"
+      },
+      {
+        "name": "Backing file chain",
+        "description": "Image depends on an external backing file which may contain additional data",
+        "condition": "backingFileOffset > 0"
+      }
+    ]
+  },
+  "aiHints": {
+    "analysisContext": "QEMU Copy-On-Write v2 virtual disk image with two-level cluster lookup, reference counting, and optional encryption",
+    "suggestedInspections": [
+      "Verify QFI magic signature and QCOW version field for format integrity",
+      "Check cluster_bits value is within valid range (9-21) for sane cluster sizes",
+      "Inspect encryption method and warn if deprecated AES-128-CBC is in use",
+      "Examine backing file offset to detect snapshot chain dependencies",
+      "Validate L1 table offset and size for consistency with virtual disk size",
+      "Check refcount table integrity for leaked or corrupt clusters"
+    ]
+  },
+  "navigation": {
+    "bookmarks": [
+      {
+        "name": "QCOW2 Header",
+        "offsetVar": "currentOffset",
+        "icon": "header"
+      },
+      {
+        "name": "L1 Table",
+        "offsetVar": "l1TableOffset",
+        "icon": "table"
+      },
+      {
+        "name": "Refcount Table",
+        "offsetVar": "refcountTableOffset",
+        "icon": "table"
+      },
+      {
+        "name": "Snapshot Table",
+        "offsetVar": "snapshotsOffset",
+        "icon": "snapshot"
+      }
+    ]
+  },
+  "TechnicalDetails": {
+    "headerSize": 72,
+    "endianness": "big",
+    "addressingScheme": "Two-level lookup: L1 table points to L2 tables, L2 entries point to data clusters",
+    "clusterManagement": "Copy-on-write via reference counting; clusters shared between snapshots",
+    "backingFiles": "Overlay images reference a parent backing file for unmodified clusters",
+    "encryption": "Optional per-image AES-128-CBC (v1, deprecated) or LUKS (v2, recommended)",
+    "compression": "Per-cluster zlib or zstd compression (v3)",
+    "snapshotSupport": "Internal snapshots stored in snapshot table with L1 table copies",
+    "maxVirtualSize": "Effectively unlimited (64-bit virtual size field)"
+  },
+  "inspector": {
+    "badge": "magic",
+    "primaryField": "qcowVersion",
+    "showQualityScore": true,
+    "groups": [
+      {
+        "title": "QCOW2 Header",
+        "icon": "header",
+        "fields": [
+          "magic",
+          "qcowVersion",
+          "virtualSize",
+          "clusterBits"
+        ]
+      },
+      {
+        "title": "Encryption",
+        "icon": "lock",
+        "fields": [
+          "cryptMethod"
+        ]
+      },
+      {
+        "title": "Backing File",
+        "icon": "link",
+        "fields": [
+          "backingFileOffset",
+          "backingFileSize"
+        ]
+      },
+      {
+        "title": "Tables and Snapshots",
+        "icon": "table",
+        "fields": [
+          "l1Size",
+          "l1TableOffset",
+          "refcountTableOffset",
+          "refcountTableClusters",
+          "nbSnapshots",
+          "snapshotsOffset"
+        ]
+      }
+    ]
+  },
+  "exportTemplates": [
+    {
+      "name": "QCOW2 Header (JSON)",
+      "format": "json",
+      "fields": [
+        "magic",
+        "qcowVersion",
+        "virtualSize",
+        "clusterBits",
+        "cryptMethod",
+        "l1Size",
+        "l1TableOffset",
+        "nbSnapshots"
+      ]
+    },
+    {
+      "name": "QCOW2 Summary (CSV)",
+      "format": "csv",
+      "fields": [
+        "qcowVersion",
+        "virtualSize",
+        "clusterBits",
+        "cryptMethod",
+        "nbSnapshots"
+      ]
+    }
+  ],
+  "assertions": [
+    {
+      "name": "magic valid",
+      "expression": "magic == 0x514649FB",
+      "severity": "error",
+      "message": "QCOW2 magic must be 0x514649FB (QFI\\xFB)"
+    },
+    {
+      "name": "version valid",
+      "expression": "qcowVersion == 2 || qcowVersion == 3",
+      "severity": "error",
+      "message": "QCOW version must be 2 or 3"
+    },
+    {
+      "name": "cluster bits range",
+      "expression": "clusterBits >= 9 && clusterBits <= 21",
+      "severity": "error",
+      "message": "Cluster bits must be between 9 (512B) and 21 (2MB)"
+    },
+    {
+      "name": "crypt method valid",
+      "expression": "cryptMethod >= 0 && cryptMethod <= 2",
+      "severity": "warning",
+      "message": "Encryption method must be 0 (none), 1 (AES), or 2 (LUKS)"
+    },
+    {
+      "name": "virtual size non-zero",
+      "expression": "virtualSize > 0",
+      "severity": "error",
+      "message": "Virtual disk size must be greater than zero"
+    }
+  ],
+  "functions": {
+    "readUInt32BE": "Read big-endian 32-bit header fields",
+    "readUInt64BE": "Read big-endian 64-bit offset and size fields",
+    "formatFileSize(var:virtualSize)": "Format virtual disk size as readable size"
+  }
+}

--- a/Sources/Core/WpfHexEditor.Core.Definitions/FormatDefinitions/Disk/SQUASHFS.whfmt
+++ b/Sources/Core/WpfHexEditor.Core.Definitions/FormatDefinitions/Disk/SQUASHFS.whfmt
@@ -1,0 +1,514 @@
+{
+  "diffMode": "binary",
+  "formatName": "SquashFS Filesystem",
+  "version": "1.0",
+  "extensions": [
+    ".squashfs",
+    ".sqfs",
+    ".sfs",
+    ".snap"
+  ],
+  "description": "SquashFS read-only compressed filesystem used in Linux distributions, Snap packages, and embedded systems",
+  "category": "Disk",
+  "author": "WPFHexaEditor Team",
+  "preferredEditor": "hex-editor",
+  "references": {
+    "specifications": [
+      "SquashFS 4.0 Filesystem Specification",
+      "SquashFS Superblock Structure",
+      "Linux Kernel SquashFS Documentation"
+    ],
+    "WebLinks": [
+      "https://en.wikipedia.org/wiki/SquashFS",
+      "https://dr-ं.github.io/squashfs/",
+      "https://github.com/plougher/squashfs-tools",
+      "https://www.kernel.org/doc/html/latest/filesystems/squashfs.html"
+    ]
+  },
+  "detection": {
+    "required": true,
+    "validation": {
+      "minFileSize": 96,
+      "maxSignatureOffset": 0
+    },
+    "signatures": [
+      {
+        "value": "68737173",
+        "offset": 0,
+        "label": "'hsqs' — SquashFS little-endian superblock magic",
+        "weight": 1.0
+      },
+      {
+        "value": "73717368",
+        "offset": 0,
+        "label": "'sqsh' — SquashFS big-endian superblock magic",
+        "weight": 0.9
+      }
+    ],
+    "matchMode": "any",
+    "MinimumScore": 0.9,
+    "Strength": "Strong",
+    "EntropyHint": {
+      "min": 6.0,
+      "max": 8.0
+    }
+  },
+  "variables": {
+    "currentOffset": 0,
+    "magic": 0,
+    "inodeCount": 0,
+    "modificationTime": 0,
+    "blockSize": 0,
+    "fragmentEntryCount": 0,
+    "compressionId": 0,
+    "blockLog": 0,
+    "flags": 0,
+    "noIds": 0,
+    "versionMajor": 0,
+    "versionMinor": 0,
+    "rootInode": 0,
+    "bytesUsed": 0,
+    "idTableStart": 0,
+    "inodeTableStart": 0,
+    "directoryTableStart": 0,
+    "fragmentTableStart": 0
+  },
+  "blocks": [
+    {
+      "type": "signature",
+      "name": "SquashFS Magic",
+      "offset": 0,
+      "length": 4,
+      "color": "#FF6B6B",
+      "opacity": 0.4,
+      "description": "'hsqs' (LE) or 'sqsh' (BE) magic identifying a SquashFS superblock",
+      "storeAs": "magic",
+      "valueType": "ascii"
+    },
+    {
+      "type": "field",
+      "name": "Inode Count",
+      "offset": 4,
+      "length": 4,
+      "color": "#4ECDC4",
+      "opacity": 0.3,
+      "description": "Total number of inodes in the filesystem",
+      "storeAs": "inodeCount",
+      "valueType": "uint32"
+    },
+    {
+      "type": "field",
+      "name": "Modification Time",
+      "offset": 8,
+      "length": 4,
+      "color": "#95E1D3",
+      "opacity": 0.3,
+      "description": "Unix timestamp of filesystem creation or last append",
+      "storeAs": "modificationTime",
+      "valueType": "uint32"
+    },
+    {
+      "type": "field",
+      "name": "Block Size",
+      "offset": 12,
+      "length": 4,
+      "color": "#FFD93D",
+      "opacity": 0.3,
+      "description": "Data block size in bytes (typically 131072 = 128KB)",
+      "storeAs": "blockSize",
+      "valueType": "uint32"
+    },
+    {
+      "type": "field",
+      "name": "Fragment Entry Count",
+      "offset": 16,
+      "length": 4,
+      "color": "#A8E6CF",
+      "opacity": 0.3,
+      "description": "Number of fragment table entries",
+      "storeAs": "fragmentEntryCount",
+      "valueType": "uint32"
+    },
+    {
+      "type": "field",
+      "name": "Compression ID",
+      "offset": 20,
+      "length": 2,
+      "color": "#6C5CE7",
+      "opacity": 0.3,
+      "description": "Compression algorithm used for data and metadata blocks",
+      "storeAs": "compressionId",
+      "valueType": "uint16",
+      "valueMap": {
+        "1": "gzip",
+        "2": "lzma",
+        "3": "lzo",
+        "4": "xz",
+        "5": "lz4",
+        "6": "zstd"
+      }
+    },
+    {
+      "type": "field",
+      "name": "Block Log",
+      "offset": 22,
+      "length": 2,
+      "color": "#E17055",
+      "opacity": 0.3,
+      "description": "Log2 of the block size (must match block_size)",
+      "storeAs": "blockLog",
+      "valueType": "uint16"
+    },
+    {
+      "type": "field",
+      "name": "Flags",
+      "offset": 24,
+      "length": 2,
+      "color": "#00B894",
+      "opacity": 0.3,
+      "description": "Superblock flags (uncompressed inodes/data/fragments, no xattrs, exportable, etc.)",
+      "storeAs": "flags",
+      "valueType": "uint16"
+    },
+    {
+      "type": "field",
+      "name": "ID Count",
+      "offset": 26,
+      "length": 2,
+      "color": "#0984E3",
+      "opacity": 0.3,
+      "description": "Number of unique UID/GID entries in the ID lookup table",
+      "storeAs": "noIds",
+      "valueType": "uint16"
+    },
+    {
+      "type": "field",
+      "name": "Version Major",
+      "offset": 28,
+      "length": 2,
+      "color": "#FDCB6E",
+      "opacity": 0.3,
+      "description": "SquashFS major version (must be 4)",
+      "storeAs": "versionMajor",
+      "valueType": "uint16"
+    },
+    {
+      "type": "field",
+      "name": "Version Minor",
+      "offset": 30,
+      "length": 2,
+      "color": "#E84393",
+      "opacity": 0.3,
+      "description": "SquashFS minor version (must be 0)",
+      "storeAs": "versionMinor",
+      "valueType": "uint16"
+    },
+    {
+      "type": "field",
+      "name": "Root Inode",
+      "offset": 32,
+      "length": 8,
+      "color": "#74B9FF",
+      "opacity": 0.3,
+      "description": "Reference to the root directory inode",
+      "storeAs": "rootInode",
+      "valueType": "uint64"
+    },
+    {
+      "type": "field",
+      "name": "Bytes Used",
+      "offset": 40,
+      "length": 8,
+      "color": "#A29BFE",
+      "opacity": 0.3,
+      "description": "Total size of the filesystem image in bytes",
+      "storeAs": "bytesUsed",
+      "valueType": "uint64"
+    },
+    {
+      "type": "field",
+      "name": "ID Table Start",
+      "offset": 48,
+      "length": 8,
+      "color": "#FD79A8",
+      "opacity": 0.3,
+      "description": "Byte offset of the UID/GID lookup table",
+      "storeAs": "idTableStart",
+      "valueType": "uint64"
+    },
+    {
+      "type": "field",
+      "name": "Inode Table Start",
+      "offset": 64,
+      "length": 8,
+      "color": "#55EFC4",
+      "opacity": 0.3,
+      "description": "Byte offset of the inode table",
+      "storeAs": "inodeTableStart",
+      "valueType": "uint64"
+    },
+    {
+      "type": "field",
+      "name": "Directory Table Start",
+      "offset": 72,
+      "length": 8,
+      "color": "#81ECEC",
+      "opacity": 0.3,
+      "description": "Byte offset of the directory table",
+      "storeAs": "directoryTableStart",
+      "valueType": "uint64"
+    },
+    {
+      "type": "field",
+      "name": "Fragment Table Start",
+      "offset": 80,
+      "length": 8,
+      "color": "#FAB1A0",
+      "opacity": 0.3,
+      "description": "Byte offset of the fragment table",
+      "storeAs": "fragmentTableStart",
+      "valueType": "uint64"
+    }
+  ],
+  "software": [
+    "mksquashfs",
+    "unsquashfs",
+    "squashfuse"
+  ],
+  "formatRelationships": {
+    "category": "Disk",
+    "extensions": [
+      ".squashfs",
+      ".sqfs",
+      ".sfs",
+      ".snap"
+    ],
+    "relatedFormats": [
+      "EXT4",
+      "EROFS",
+      "CramFS",
+      "ISO"
+    ]
+  },
+  "MimeTypes": [
+    "application/vnd.squashfs",
+    "application/octet-stream"
+  ],
+  "Software": [
+    "mksquashfs (squashfs-tools)",
+    "unsquashfs (squashfs-tools)",
+    "squashfuse (FUSE mount)",
+    "7-Zip",
+    "file-roller",
+    "snapd (Ubuntu Snap)",
+    "AppImageTool"
+  ],
+  "UseCases": [
+    "Linux live CD and installer root filesystems",
+    "Ubuntu Snap package container format",
+    "AppImage application bundle filesystem layer",
+    "Docker overlay and container image layers",
+    "Embedded Linux firmware root filesystems (OpenWrt, Yocto)",
+    "Read-only system partitions in IoT devices",
+    "Forensic examination of compressed filesystem images"
+  ],
+  "QualityMetrics": {
+    "CompletenessScore": 92,
+    "DocumentationLevel": "detailed",
+    "BlocksDefined": 17,
+    "ValidationRules": 5,
+    "LastUpdated": "2026-04-14",
+    "PriorityFormat": true,
+    "AutoRefined": false
+  },
+  "forensic": {
+    "category": "disk",
+    "riskLevel": "low",
+    "suspiciousPatterns": [
+      {
+        "name": "Non-standard compression algorithm",
+        "description": "Compression ID outside commonly expected range may indicate a modified or unusual build",
+        "condition": "compressionId > 6"
+      },
+      {
+        "name": "Unusually large inode count",
+        "description": "Very high inode count could indicate a filesystem packed with many small files for obfuscation",
+        "condition": "inodeCount > 1000000"
+      }
+    ]
+  },
+  "aiHints": {
+    "analysisContext": "SquashFS read-only compressed filesystem with block-level compression, used in Linux distributions, Snap packages, and embedded systems",
+    "suggestedInspections": [
+      "Verify 'hsqs' or 'sqsh' magic and confirm version is 4.0 for format integrity",
+      "Check compression algorithm ID and validate it matches a known compressor (gzip/xz/zstd/lz4/lzma/lzo)",
+      "Validate block size is a power of 2 and block_log matches log2(block_size)",
+      "Inspect modification timestamp for filesystem creation timeline analysis",
+      "Examine superblock flags for uncompressed metadata or disabled features",
+      "Calculate expected filesystem size from bytes_used and compare with actual file size"
+    ]
+  },
+  "navigation": {
+    "bookmarks": [
+      {
+        "name": "Superblock",
+        "offsetVar": "currentOffset",
+        "icon": "header"
+      },
+      {
+        "name": "ID Table",
+        "offsetVar": "idTableStart",
+        "icon": "table"
+      },
+      {
+        "name": "Inode Table",
+        "offsetVar": "inodeTableStart",
+        "icon": "table"
+      },
+      {
+        "name": "Directory Table",
+        "offsetVar": "directoryTableStart",
+        "icon": "folder"
+      },
+      {
+        "name": "Fragment Table",
+        "offsetVar": "fragmentTableStart",
+        "icon": "fragment"
+      }
+    ]
+  },
+  "TechnicalDetails": {
+    "formatVersion": "4.0",
+    "endianness": "little (hsqs) or big (sqsh)",
+    "compressionAlgorithms": "gzip (default), lzma, lzo, xz, lz4, zstd — block-level compression",
+    "blockSizes": "Configurable 4KB to 1MB (default 128KB), must be power of 2",
+    "readOnly": "SquashFS is strictly read-only; modifications require full rebuild",
+    "inodeTypes": "Regular file, directory, symlink, block device, char device, FIFO, socket",
+    "deduplication": "Automatic detection and elimination of duplicate data blocks",
+    "fragmentPacking": "Files smaller than block size are packed into shared fragment blocks",
+    "xattrSupport": "Extended attributes stored in a separate xattr table",
+    "exportSupport": "Optional NFS export via inode number lookup table"
+  },
+  "inspector": {
+    "badge": "magic",
+    "primaryField": "compressionId",
+    "showQualityScore": true,
+    "groups": [
+      {
+        "title": "Superblock Identity",
+        "icon": "header",
+        "fields": [
+          "magic",
+          "versionMajor",
+          "versionMinor",
+          "flags"
+        ]
+      },
+      {
+        "title": "Filesystem Metrics",
+        "icon": "chart",
+        "fields": [
+          "inodeCount",
+          "bytesUsed",
+          "blockSize",
+          "blockLog",
+          "noIds"
+        ]
+      },
+      {
+        "title": "Compression",
+        "icon": "compress",
+        "fields": [
+          "compressionId",
+          "fragmentEntryCount"
+        ]
+      },
+      {
+        "title": "Table Offsets",
+        "icon": "table",
+        "fields": [
+          "rootInode",
+          "idTableStart",
+          "inodeTableStart",
+          "directoryTableStart",
+          "fragmentTableStart"
+        ]
+      },
+      {
+        "title": "Timestamp",
+        "icon": "clock",
+        "fields": [
+          "modificationTime"
+        ]
+      }
+    ]
+  },
+  "exportTemplates": [
+    {
+      "name": "SquashFS Header (JSON)",
+      "format": "json",
+      "fields": [
+        "magic",
+        "versionMajor",
+        "versionMinor",
+        "inodeCount",
+        "blockSize",
+        "compressionId",
+        "flags",
+        "bytesUsed",
+        "modificationTime"
+      ]
+    },
+    {
+      "name": "SquashFS Summary (CSV)",
+      "format": "csv",
+      "fields": [
+        "versionMajor",
+        "versionMinor",
+        "inodeCount",
+        "blockSize",
+        "compressionId",
+        "bytesUsed"
+      ]
+    }
+  ],
+  "assertions": [
+    {
+      "name": "magic valid",
+      "expression": "magic == 'hsqs' || magic == 'sqsh'",
+      "severity": "error",
+      "message": "SquashFS magic must be 'hsqs' (little-endian) or 'sqsh' (big-endian)"
+    },
+    {
+      "name": "version major is 4",
+      "expression": "versionMajor == 4",
+      "severity": "error",
+      "message": "SquashFS major version must be 4"
+    },
+    {
+      "name": "compression ID valid",
+      "expression": "compressionId >= 1 && compressionId <= 6",
+      "severity": "error",
+      "message": "Compression ID must be 1-6 (gzip/lzma/lzo/xz/lz4/zstd)"
+    },
+    {
+      "name": "block size power of 2",
+      "expression": "blockSize >= 4096 && blockSize <= 1048576",
+      "severity": "warning",
+      "message": "Block size should be a power of 2 between 4KB and 1MB"
+    },
+    {
+      "name": "bytes used non-zero",
+      "expression": "bytesUsed > 0",
+      "severity": "error",
+      "message": "Filesystem bytes used must be greater than zero"
+    }
+  ],
+  "functions": {
+    "readUInt32LE": "Read little-endian 32-bit superblock fields",
+    "readUInt16LE": "Read little-endian 16-bit fields (compression, version, flags)",
+    "readUInt64LE": "Read little-endian 64-bit offset fields",
+    "formatFileSize(var:bytesUsed)": "Format filesystem size as readable size",
+    "formatTimestamp(var:modificationTime)": "Format Unix timestamp as human-readable date"
+  }
+}

--- a/Sources/Core/WpfHexEditor.Core.Definitions/FormatDefinitions/Disk/VHDX.whfmt
+++ b/Sources/Core/WpfHexEditor.Core.Definitions/FormatDefinitions/Disk/VHDX.whfmt
@@ -1,0 +1,378 @@
+{
+  "diffMode": "binary",
+  "formatName": "VHDX Virtual Hard Disk",
+  "version": "1.0",
+  "extensions": [
+    ".vhdx"
+  ],
+  "description": "Microsoft Virtual Hard Disk v2 format with crash-consistent redundant metadata and 64TB support",
+  "category": "Disk",
+  "author": "WPFHexaEditor Team",
+  "preferredEditor": "hex-editor",
+  "references": {
+    "specifications": [
+      "VHDX Format Specification v1.0 (MS-VHDX)",
+      "Microsoft Virtual Hard Disk v2 Technical Reference",
+      "Hyper-V Virtual Hard Disk Specification"
+    ],
+    "WebLinks": [
+      "https://en.wikipedia.org/wiki/VHD_(file_format)#VHDX",
+      "https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-vhdx",
+      "https://github.com/libyal/libvhdi/blob/main/documentation/Virtual%20Hard%20Disk%20(VHD)%20image%20format.asciidoc",
+      "https://learn.microsoft.com/en-us/windows-server/storage/disk-management/manage-virtual-hard-disks"
+    ]
+  },
+  "detection": {
+    "required": true,
+    "validation": {
+      "minFileSize": 8,
+      "maxSignatureOffset": 0
+    },
+    "signatures": [
+      {
+        "value": "7668647866696C65",
+        "offset": 0,
+        "label": "'vhdxfile' — VHDX File Type Identifier at offset 0",
+        "weight": 1.0
+      }
+    ],
+    "matchMode": "any",
+    "MinimumScore": 1.0,
+    "Strength": "Strong",
+    "EntropyHint": {
+      "min": 1.0,
+      "max": 7.5
+    }
+  },
+  "variables": {
+    "currentOffset": 0,
+    "fileTypeId": 0,
+    "creatorByte0": 0,
+    "creatorByte2": 0,
+    "header1Signature": 0,
+    "header1SequenceNumber": 0,
+    "header1Version": 0,
+    "header1LogLength": 0,
+    "header1LogOffset": 0,
+    "regionTable1Signature": 0,
+    "regionTable1EntryCount": 0
+  },
+  "blocks": [
+    {
+      "type": "signature",
+      "name": "File Type Identifier",
+      "offset": 0,
+      "length": 8,
+      "color": "#FF6B6B",
+      "opacity": 0.4,
+      "description": "'vhdxfile' ASCII identifier at the start of the file",
+      "storeAs": "fileTypeId",
+      "valueType": "ascii"
+    },
+    {
+      "type": "field",
+      "name": "Creator (UTF-16 Start)",
+      "offset": 8,
+      "length": 2,
+      "color": "#4ECDC4",
+      "opacity": 0.3,
+      "description": "First UTF-16 LE character of the creator tool name",
+      "storeAs": "creatorByte0",
+      "valueType": "uint16"
+    },
+    {
+      "type": "field",
+      "name": "Creator (UTF-16 Byte 2)",
+      "offset": 10,
+      "length": 2,
+      "color": "#95E1D3",
+      "opacity": 0.3,
+      "description": "Second UTF-16 LE character of the creator tool name",
+      "storeAs": "creatorByte2",
+      "valueType": "uint16"
+    },
+    {
+      "type": "field",
+      "name": "Header 1 Signature",
+      "offset": 65536,
+      "length": 4,
+      "color": "#FFD93D",
+      "opacity": 0.3,
+      "description": "'head' signature of the first redundant VHDX header at 64KB",
+      "storeAs": "header1Signature",
+      "valueType": "ascii"
+    },
+    {
+      "type": "field",
+      "name": "Header 1 Sequence Number",
+      "offset": 65544,
+      "length": 8,
+      "color": "#6C5CE7",
+      "opacity": 0.3,
+      "description": "Sequence number for determining active header (higher wins)",
+      "storeAs": "header1SequenceNumber",
+      "valueType": "uint64"
+    },
+    {
+      "type": "field",
+      "name": "Header 1 Version",
+      "offset": 65588,
+      "length": 2,
+      "color": "#E17055",
+      "opacity": 0.3,
+      "description": "VHDX format version in header 1",
+      "storeAs": "header1Version",
+      "valueType": "uint16"
+    },
+    {
+      "type": "field",
+      "name": "Header 1 Log Length",
+      "offset": 65592,
+      "length": 4,
+      "color": "#00B894",
+      "opacity": 0.3,
+      "description": "Length of the log region in bytes",
+      "storeAs": "header1LogLength",
+      "valueType": "uint32"
+    },
+    {
+      "type": "field",
+      "name": "Header 1 Log Offset",
+      "offset": 65596,
+      "length": 8,
+      "color": "#0984E3",
+      "opacity": 0.3,
+      "description": "Byte offset of the log region within the file",
+      "storeAs": "header1LogOffset",
+      "valueType": "uint64"
+    },
+    {
+      "type": "field",
+      "name": "Region Table 1 Signature",
+      "offset": 196608,
+      "length": 4,
+      "color": "#FDCB6E",
+      "opacity": 0.3,
+      "description": "'regi' signature of the first region table at 192KB",
+      "storeAs": "regionTable1Signature",
+      "valueType": "ascii"
+    },
+    {
+      "type": "field",
+      "name": "Region Table 1 Entry Count",
+      "offset": 196620,
+      "length": 4,
+      "color": "#E84393",
+      "opacity": 0.3,
+      "description": "Number of region table entries (BAT + Metadata regions)",
+      "storeAs": "regionTable1EntryCount",
+      "valueType": "uint32"
+    }
+  ],
+  "software": [
+    "Microsoft Hyper-V",
+    "diskpart",
+    "DISM"
+  ],
+  "formatRelationships": {
+    "category": "Disk",
+    "extensions": [
+      ".vhdx"
+    ],
+    "relatedFormats": [
+      "VHD",
+      "QCOW2",
+      "VMDK",
+      "VDI"
+    ]
+  },
+  "MimeTypes": [
+    "application/x-vhdx",
+    "application/octet-stream"
+  ],
+  "Software": [
+    "Microsoft Hyper-V",
+    "diskpart",
+    "DISM",
+    "qemu-img (convert)",
+    "PowerShell (Mount-VHD / New-VHD)",
+    "7-Zip",
+    "StarWind V2V Converter"
+  ],
+  "UseCases": [
+    "Hyper-V virtual machine disk storage",
+    "Windows Server virtualization",
+    "Azure virtual machine disk uploads",
+    "Forensic analysis of Windows VM disk images",
+    "Disk migration and format conversion",
+    "System backup and disaster recovery"
+  ],
+  "QualityMetrics": {
+    "CompletenessScore": 89,
+    "DocumentationLevel": "detailed",
+    "BlocksDefined": 10,
+    "ValidationRules": 4,
+    "LastUpdated": "2026-04-14",
+    "PriorityFormat": true,
+    "AutoRefined": false
+  },
+  "forensic": {
+    "category": "disk",
+    "riskLevel": "medium",
+    "suspiciousPatterns": [
+      {
+        "name": "Mismatched header sequence numbers",
+        "description": "Header 1 and Header 2 have divergent sequence numbers, indicating possible incomplete write or tampering",
+        "condition": "header1SequenceNumber == 0"
+      },
+      {
+        "name": "Non-empty log region",
+        "description": "A non-zero log length suggests a replay log exists, possibly from an unclean shutdown",
+        "condition": "header1LogLength > 0"
+      }
+    ]
+  },
+  "aiHints": {
+    "analysisContext": "Microsoft VHDX virtual hard disk v2 with 1MB-aligned redundant metadata, CRC-32C checksums, and crash-consistent journal",
+    "suggestedInspections": [
+      "Verify 'vhdxfile' file type identifier and 'head' header signatures for format integrity",
+      "Compare Header 1 and Header 2 sequence numbers to determine which header is active",
+      "Check region table for BAT and Metadata region entries with correct GUIDs",
+      "Inspect log region offset and length for evidence of pending replay operations",
+      "Validate CRC-32C checksums in headers and region tables for data integrity",
+      "Examine metadata region for VirtualDiskSize, LogicalSectorSize, and ParentLocator items"
+    ]
+  },
+  "navigation": {
+    "bookmarks": [
+      {
+        "name": "File Type Identifier",
+        "offsetVar": "currentOffset",
+        "icon": "header"
+      },
+      {
+        "name": "Header 1 (64KB)",
+        "offset": 65536,
+        "icon": "header"
+      },
+      {
+        "name": "Header 2 (128KB)",
+        "offset": 131072,
+        "icon": "header"
+      },
+      {
+        "name": "Region Table 1 (192KB)",
+        "offset": 196608,
+        "icon": "table"
+      },
+      {
+        "name": "Log Region",
+        "offsetVar": "header1LogOffset",
+        "icon": "journal"
+      }
+    ]
+  },
+  "TechnicalDetails": {
+    "alignment": "All metadata structures are 1MB aligned for optimal I/O",
+    "redundancy": "Two copies each of headers and region tables for crash consistency",
+    "checksums": "CRC-32C (Castagnoli) used for headers and region tables",
+    "blockAllocation": "BAT (Block Allocation Table) maps virtual blocks to file offsets",
+    "blockSizes": "Configurable block sizes from 1MB to 256MB",
+    "maxDiskSize": "64 TB maximum virtual disk size",
+    "sectorSizes": "Logical sector size 512B or 4KB; physical sector size 512B or 4KB",
+    "journaling": "Write-ahead log for atomic metadata updates",
+    "metadataItems": "VirtualDiskSize, VirtualDiskId, LogicalSectorSize, PhysicalSectorSize, ParentLocator"
+  },
+  "inspector": {
+    "badge": "fileTypeId",
+    "primaryField": "header1Version",
+    "showQualityScore": true,
+    "groups": [
+      {
+        "title": "File Identifier",
+        "icon": "header",
+        "fields": [
+          "fileTypeId",
+          "creatorByte0",
+          "creatorByte2"
+        ]
+      },
+      {
+        "title": "Header 1",
+        "icon": "header",
+        "fields": [
+          "header1Signature",
+          "header1SequenceNumber",
+          "header1Version",
+          "header1LogLength",
+          "header1LogOffset"
+        ]
+      },
+      {
+        "title": "Region Table",
+        "icon": "table",
+        "fields": [
+          "regionTable1Signature",
+          "regionTable1EntryCount"
+        ]
+      }
+    ]
+  },
+  "exportTemplates": [
+    {
+      "name": "VHDX Header (JSON)",
+      "format": "json",
+      "fields": [
+        "fileTypeId",
+        "header1Signature",
+        "header1SequenceNumber",
+        "header1Version",
+        "header1LogLength",
+        "header1LogOffset",
+        "regionTable1Signature",
+        "regionTable1EntryCount"
+      ]
+    },
+    {
+      "name": "VHDX Summary (CSV)",
+      "format": "csv",
+      "fields": [
+        "header1Version",
+        "header1SequenceNumber",
+        "header1LogLength",
+        "regionTable1EntryCount"
+      ]
+    }
+  ],
+  "assertions": [
+    {
+      "name": "file type identifier valid",
+      "expression": "fileTypeId == 'vhdxfile'",
+      "severity": "error",
+      "message": "VHDX file type identifier must be 'vhdxfile'"
+    },
+    {
+      "name": "header 1 signature valid",
+      "expression": "header1Signature == 'head'",
+      "severity": "error",
+      "message": "VHDX Header 1 signature must be 'head' at offset 64KB"
+    },
+    {
+      "name": "region table 1 signature valid",
+      "expression": "regionTable1Signature == 'regi'",
+      "severity": "error",
+      "message": "VHDX Region Table 1 signature must be 'regi' at offset 192KB"
+    },
+    {
+      "name": "region table entry count valid",
+      "expression": "regionTable1EntryCount >= 1 && regionTable1EntryCount <= 2047",
+      "severity": "warning",
+      "message": "Region table entry count should be between 1 and 2047"
+    }
+  ],
+  "functions": {
+    "readUInt32LE": "Read little-endian 32-bit header fields",
+    "readUInt64LE": "Read little-endian 64-bit offset and size fields",
+    "readAscii": "Read ASCII signature strings"
+  }
+}

--- a/Sources/Core/WpfHexEditor.Core.Definitions/FormatDefinitions/Game/ROM_3DS.whfmt
+++ b/Sources/Core/WpfHexEditor.Core.Definitions/FormatDefinitions/Game/ROM_3DS.whfmt
@@ -1,0 +1,444 @@
+{
+  "diffMode": "binary",
+  "formatName": "Nintendo 3DS ROM",
+  "version": "1.0",
+  "extensions": [
+    ".3ds",
+    ".cia"
+  ],
+  "description": "Nintendo 3DS ROM images in NCSD (.3ds) and CIA formats with RSA-2048 signatures, NCCH partitions, and AES-128-CTR encryption",
+  "category": "Game",
+  "author": "WPFHexaEditor Team",
+  "preferredEditor": "hex-editor",
+  "references": {
+    "specifications": [
+      "3DBrew NCSD Format Documentation",
+      "3DBrew NCCH Format Documentation",
+      "Nintendo 3DS Cartridge Header Specification"
+    ],
+    "WebLinks": [
+      "https://www.3dbrew.org/wiki/NCSD",
+      "https://www.3dbrew.org/wiki/NCCH",
+      "https://www.3dbrew.org/wiki/CIA",
+      "https://en.wikipedia.org/wiki/Nintendo_3DS"
+    ]
+  },
+  "detection": {
+    "required": true,
+    "validation": {
+      "minFileSize": 512,
+      "maxSignatureOffset": 260
+    },
+    "signatures": [
+      {
+        "value": "4E435344",
+        "offset": 256,
+        "label": "'NCSD' — Nintendo 3DS cartridge image header at offset 0x100",
+        "weight": 1.0
+      },
+      {
+        "value": "4E434348",
+        "offset": 256,
+        "label": "'NCCH' — Nintendo 3DS NCCH partition magic at offset 0x100 (CIA extracted content)",
+        "weight": 0.7
+      }
+    ],
+    "matchMode": "any",
+    "MinimumScore": 0.7,
+    "Strength": "Strong",
+    "EntropyHint": {
+      "min": 4.0,
+      "max": 7.5
+    }
+  },
+  "variables": {
+    "currentOffset": 0,
+    "rsaSignature": "",
+    "ncsdMagic": "",
+    "imageSize": 0,
+    "mediaId": 0,
+    "partitionsFsType": 0,
+    "partitionsCryptType": 0,
+    "partition0Offset": 0,
+    "partition0Size": 0,
+    "partition1Offset": 0,
+    "partition1Size": 0,
+    "exheaderHash": "",
+    "additionalHeaderSize": 0,
+    "sectorZeroOffset": 0,
+    "flags": 0
+  },
+  "blocks": [
+    {
+      "type": "field",
+      "name": "RSA-2048 Signature",
+      "offset": 0,
+      "length": 256,
+      "color": "#636E72",
+      "opacity": 0.3,
+      "valueType": "bytes",
+      "storeAs": "rsaSignature",
+      "description": "RSA-2048 SHA-256 signature of the NCSD header"
+    },
+    {
+      "type": "signature",
+      "name": "NCSD Magic",
+      "offset": 256,
+      "length": 4,
+      "color": "#FF6B6B",
+      "opacity": 0.4,
+      "description": "'NCSD' magic identifying this as a Nintendo 3DS cartridge image",
+      "storeAs": "ncsdMagic",
+      "valueType": "ascii"
+    },
+    {
+      "type": "field",
+      "name": "Image Size",
+      "offset": 260,
+      "length": 4,
+      "color": "#4ECDC4",
+      "opacity": 0.3,
+      "valueType": "uint32",
+      "storeAs": "imageSize",
+      "description": "Image size in media units (1 media unit = 0x200 bytes)"
+    },
+    {
+      "type": "field",
+      "name": "Media ID",
+      "offset": 264,
+      "length": 8,
+      "color": "#FDCB6E",
+      "opacity": 0.3,
+      "valueType": "uint64",
+      "storeAs": "mediaId",
+      "description": "Title ID of the cartridge content"
+    },
+    {
+      "type": "field",
+      "name": "Partitions FS Type",
+      "offset": 272,
+      "length": 8,
+      "color": "#C7CEEA",
+      "opacity": 0.3,
+      "valueType": "bytes",
+      "storeAs": "partitionsFsType",
+      "description": "Filesystem types for each of the 8 partitions"
+    },
+    {
+      "type": "field",
+      "name": "Partitions Crypt Type",
+      "offset": 280,
+      "length": 8,
+      "color": "#C7CEEA",
+      "opacity": 0.3,
+      "valueType": "bytes",
+      "storeAs": "partitionsCryptType",
+      "description": "Encryption types for each of the 8 partitions"
+    },
+    {
+      "type": "field",
+      "name": "Partition 0 Offset",
+      "offset": 288,
+      "length": 4,
+      "color": "#6C5CE7",
+      "opacity": 0.3,
+      "valueType": "uint32",
+      "storeAs": "partition0Offset",
+      "description": "Game content partition offset in media units (partition 0 = main game NCCH)"
+    },
+    {
+      "type": "field",
+      "name": "Partition 0 Size",
+      "offset": 292,
+      "length": 4,
+      "color": "#6C5CE7",
+      "opacity": 0.3,
+      "valueType": "uint32",
+      "storeAs": "partition0Size",
+      "description": "Game content partition size in media units"
+    },
+    {
+      "type": "field",
+      "name": "Partition 1 Offset",
+      "offset": 296,
+      "length": 4,
+      "color": "#E17055",
+      "opacity": 0.3,
+      "valueType": "uint32",
+      "storeAs": "partition1Offset",
+      "description": "Manual/eManual partition offset in media units"
+    },
+    {
+      "type": "field",
+      "name": "Partition 1 Size",
+      "offset": 300,
+      "length": 4,
+      "color": "#E17055",
+      "opacity": 0.3,
+      "valueType": "uint32",
+      "storeAs": "partition1Size",
+      "description": "Manual/eManual partition size in media units"
+    },
+    {
+      "type": "field",
+      "name": "ExHeader Hash",
+      "offset": 352,
+      "length": 32,
+      "color": "#FF6B9D",
+      "opacity": 0.3,
+      "valueType": "bytes",
+      "storeAs": "exheaderHash",
+      "description": "SHA-256 hash of the extended header"
+    },
+    {
+      "type": "field",
+      "name": "Additional Header Size",
+      "offset": 384,
+      "length": 4,
+      "color": "#C7CEEA",
+      "opacity": 0.3,
+      "valueType": "uint32",
+      "storeAs": "additionalHeaderSize",
+      "description": "Additional header size in bytes"
+    },
+    {
+      "type": "field",
+      "name": "Sector Zero Offset",
+      "offset": 388,
+      "length": 4,
+      "color": "#C7CEEA",
+      "opacity": 0.3,
+      "valueType": "uint32",
+      "storeAs": "sectorZeroOffset",
+      "description": "Offset of sector zero within the NCSD image"
+    },
+    {
+      "type": "field",
+      "name": "Flags",
+      "offset": 392,
+      "length": 8,
+      "color": "#00B894",
+      "opacity": 0.3,
+      "valueType": "bytes",
+      "storeAs": "flags",
+      "description": "Partition flags (media type, crypto method, media unit size)"
+    },
+    {
+      "type": "metadata",
+      "name": "Format",
+      "variable": "ncsdMagic",
+      "description": "NCSD Magic"
+    },
+    {
+      "type": "metadata",
+      "name": "Media ID",
+      "variable": "mediaId",
+      "description": "Title ID"
+    }
+  ],
+  "assertions": [
+    {
+      "name": "NCSD magic valid",
+      "expression": "ncsdMagic == 'NCSD'",
+      "severity": "error",
+      "message": "NCSD header magic at offset 0x100 must be 'NCSD' (4E 43 53 44)"
+    },
+    {
+      "name": "Image size non-zero",
+      "expression": "imageSize > 0",
+      "severity": "error",
+      "message": "Image size in media units must be greater than zero"
+    },
+    {
+      "name": "First partition has valid offset",
+      "expression": "partition0Offset > 0",
+      "severity": "error",
+      "message": "Partition 0 (game content) offset must be non-zero to contain valid NCCH data"
+    },
+    {
+      "name": "First partition has valid size",
+      "expression": "partition0Size > 0",
+      "severity": "warning",
+      "message": "Partition 0 (game content) size should be non-zero for a valid cartridge image"
+    }
+  ],
+  "inspector": {
+    "badge": "ncsdMagic",
+    "primaryField": "imageSize",
+    "showQualityScore": true,
+    "groups": [
+      {
+        "title": "NCSD Header",
+        "icon": "header",
+        "fields": [
+          "ncsdMagic",
+          "imageSize",
+          "mediaId"
+        ]
+      },
+      {
+        "title": "Partition Table",
+        "icon": "folder",
+        "fields": [
+          "partition0Offset",
+          "partition0Size",
+          "partition1Offset",
+          "partition1Size"
+        ]
+      },
+      {
+        "title": "Security",
+        "icon": "lock",
+        "fields": [
+          "rsaSignature",
+          "exheaderHash",
+          "partitionsCryptType"
+        ]
+      },
+      {
+        "title": "Configuration",
+        "icon": "settings",
+        "fields": [
+          "partitionsFsType",
+          "flags",
+          "additionalHeaderSize",
+          "sectorZeroOffset"
+        ]
+      }
+    ]
+  },
+  "exportTemplates": [
+    {
+      "name": "3DS Header (JSON)",
+      "format": "json",
+      "fields": [
+        "ncsdMagic",
+        "imageSize",
+        "mediaId",
+        "partition0Offset",
+        "partition0Size",
+        "partition1Offset",
+        "partition1Size",
+        "flags"
+      ]
+    },
+    {
+      "name": "3DS Partitions (CSV)",
+      "format": "csv",
+      "fields": [
+        "partition0Offset",
+        "partition0Size",
+        "partition1Offset",
+        "partition1Size"
+      ]
+    }
+  ],
+  "navigation": {
+    "bookmarks": [
+      {
+        "name": "RSA Signature",
+        "offset": 0,
+        "icon": "lock"
+      },
+      {
+        "name": "NCSD Magic",
+        "offset": 256,
+        "icon": "signature"
+      },
+      {
+        "name": "Partition Table",
+        "offset": 288,
+        "icon": "folder"
+      },
+      {
+        "name": "ExHeader Hash",
+        "offset": 352,
+        "icon": "checksum"
+      }
+    ]
+  },
+  "software": [
+    "Citra (3DS emulator)",
+    "GodMode9 (3DS filesystem tool)",
+    "3DSExplorer (ROM analysis)",
+    "ctrtool (NCCH/NCSD extraction)",
+    "makerom (3DS ROM builder)"
+  ],
+  "formatRelationships": {
+    "category": "Game",
+    "extensions": [
+      ".3ds",
+      ".cia"
+    ],
+    "relatedFormats": [
+      "ROM_NDS"
+    ]
+  },
+  "MimeTypes": [
+    "application/x-nintendo-3ds-rom"
+  ],
+  "Software": [
+    "Citra (3DS emulator)",
+    "GodMode9 (3DS filesystem tool)",
+    "3DSExplorer (ROM analysis)",
+    "ctrtool (NCCH/NCSD extraction)",
+    "makerom (3DS ROM builder)"
+  ],
+  "UseCases": [
+    "3DS game emulation and testing",
+    "ROM dumping and archival",
+    "Homebrew development and sideloading",
+    "Game modding and translation patches"
+  ],
+  "QualityMetrics": {
+    "CompletenessScore": 90,
+    "DocumentationLevel": "detailed",
+    "BlocksDefined": 16,
+    "ValidationRules": 4,
+    "LastUpdated": "2026-04-14",
+    "PriorityFormat": true,
+    "AutoRefined": false
+  },
+  "TechnicalDetails": {
+    "endianness": "little",
+    "containerFormat": "NCSD = 8 NCCH partitions; each NCCH = ExHeader + ExeFS (code) + RomFS (data)",
+    "encryption": "RSA-2048 signatures + AES-128-CTR content encryption per partition",
+    "mediaUnit": "1 media unit = 0x200 bytes (512 bytes); all offsets/sizes in media units",
+    "exeFS": "Contains .code (ARM11 executable), icon resource, and banner data",
+    "romFS": "Read-only filesystem using IVFC hash tree verification (4 levels)",
+    "partitionLayout": "P0=Game, P1=Manual, P2=Download Play child, P6=New3DS update, P7=Update data",
+    "processor": "ARM11 MPCore (dual/quad core, up to 268MHz) + ARM9 (security processor)"
+  },
+  "forensic": {
+    "category": "game",
+    "riskLevel": "low",
+    "suspiciousPatterns": [
+      {
+        "name": "Decrypted partition detected",
+        "description": "Partition crypto type indicates no encryption, which may mean the ROM has been decrypted for emulator use",
+        "condition": "partitionsCryptType == 0"
+      },
+      {
+        "name": "Zero-filled RSA signature",
+        "description": "RSA signature area is zeroed out, indicating a modified or unsigned ROM dump",
+        "condition": "rsaSignature == 0"
+      }
+    ]
+  },
+  "aiHints": {
+    "analysisContext": "Nintendo 3DS cartridge image in NCSD format with RSA-2048 signed header, 8-partition NCCH layout, and AES-128-CTR encryption",
+    "suggestedInspections": [
+      "Verify 'NCSD' magic at offset 0x100 confirms valid 3DS cartridge dump",
+      "Check partition 0 offset and size for main game NCCH content presence",
+      "Inspect RSA-2048 signature validity (zeroed signature indicates modified ROM)",
+      "Validate image size in media units matches expected file size (imageSize * 0x200)",
+      "Examine partition crypto types to determine encryption state per partition",
+      "Check ExHeader SHA-256 hash for integrity of extended header data"
+    ]
+  },
+  "functions": {
+    "readUInt32LE": "Read little-endian 32-bit header fields",
+    "readUInt64LE": "Read little-endian 64-bit fields (media ID)",
+    "readBytes": "Read raw byte arrays (RSA signature, hash)"
+  }
+}

--- a/Sources/Core/WpfHexEditor.Core.Definitions/FormatDefinitions/Game/ROM_GBC.whfmt
+++ b/Sources/Core/WpfHexEditor.Core.Definitions/FormatDefinitions/Game/ROM_GBC.whfmt
@@ -1,0 +1,529 @@
+{
+  "diffMode": "binary",
+  "formatName": "Game Boy Color ROM",
+  "version": "1.0",
+  "extensions": [
+    ".gbc"
+  ],
+  "description": "Game Boy Color ROM images (.gbc) contain full cartridge data for the GBC handheld (1998) with MBC banking, double-speed CPU, and extended VRAM/WRAM",
+  "category": "Game",
+  "author": "WPFHexaEditor Team",
+  "preferredEditor": "hex-editor",
+  "references": {
+    "specifications": [
+      "Pan Docs - Game Boy Technical Reference",
+      "Game Boy CPU Manual",
+      "Game Boy Color Cartridge Header Format"
+    ],
+    "WebLinks": [
+      "https://gbdev.io/pandocs/The_Cartridge_Header.html",
+      "https://gbdev.io/pandocs/",
+      "https://en.wikipedia.org/wiki/Game_Boy_Color",
+      "https://gekkio.fi/files/gb-docs/gbctr.pdf"
+    ]
+  },
+  "detection": {
+    "required": true,
+    "validation": {
+      "minFileSize": 336,
+      "maxSignatureOffset": 264
+    },
+    "signatures": [
+      {
+        "value": "CEED6666",
+        "offset": 260,
+        "label": "Nintendo Logo start at offset 0x104 (identical across all licensed GB/GBC ROMs)",
+        "weight": 0.9
+      }
+    ],
+    "matchMode": "any",
+    "MinimumScore": 0.9,
+    "Strength": "Strong",
+    "EntropyHint": {
+      "min": 3.0,
+      "max": 6.5
+    }
+  },
+  "variables": {
+    "currentOffset": 0,
+    "entryPoint": 0,
+    "nintendoLogo": "",
+    "title": "",
+    "manufacturerCode": "",
+    "cgbFlag": 0,
+    "newLicenseeCode": "",
+    "sgbFlag": 0,
+    "cartridgeType": 0,
+    "romSize": 0,
+    "ramSize": 0,
+    "destinationCode": 0,
+    "oldLicenseeCode": 0,
+    "maskRomVersion": 0,
+    "headerChecksum": 0,
+    "globalChecksum": 0
+  },
+  "blocks": [
+    {
+      "type": "field",
+      "name": "Entry Point",
+      "offset": 256,
+      "length": 4,
+      "color": "#4ECDC4",
+      "opacity": 0.3,
+      "valueType": "uint32",
+      "storeAs": "entryPoint",
+      "description": "Boot entry point (typically NOP + JP $0150 = 00 C3 50 01)"
+    },
+    {
+      "type": "signature",
+      "name": "Nintendo Logo",
+      "offset": 260,
+      "length": 48,
+      "color": "#FF6B6B",
+      "opacity": 0.4,
+      "description": "Nintendo bootrom logo bitmap (48 bytes, must match exactly or boot ROM rejects cartridge)",
+      "storeAs": "nintendoLogo",
+      "valueType": "bytes"
+    },
+    {
+      "type": "field",
+      "name": "Title",
+      "offset": 308,
+      "length": 11,
+      "color": "#4ECDC4",
+      "opacity": 0.3,
+      "valueType": "ascii",
+      "storeAs": "title",
+      "description": "Game title in ASCII (null-padded, 11 bytes for GBC-era titles)"
+    },
+    {
+      "type": "field",
+      "name": "Manufacturer Code",
+      "offset": 319,
+      "length": 4,
+      "color": "#C7CEEA",
+      "opacity": 0.3,
+      "valueType": "ascii",
+      "storeAs": "manufacturerCode",
+      "description": "4-character manufacturer code (GBC-era games only)"
+    },
+    {
+      "type": "field",
+      "name": "CGB Flag",
+      "offset": 323,
+      "length": 1,
+      "color": "#FFE66D",
+      "opacity": 0.3,
+      "valueType": "uint8",
+      "storeAs": "cgbFlag",
+      "description": "0x80=GBC compatible (also runs on DMG), 0xC0=GBC only, 0x00=DMG only",
+      "valueMap": {
+        "0": "DMG only (not GBC)",
+        "128": "GBC compatible (also runs on original Game Boy)",
+        "192": "GBC only (does not run on DMG)"
+      },
+      "validationRules": {
+        "allowedValues": [0, 128, 192]
+      }
+    },
+    {
+      "type": "field",
+      "name": "New Licensee Code",
+      "offset": 324,
+      "length": 2,
+      "color": "#C7CEEA",
+      "opacity": 0.3,
+      "valueType": "ascii",
+      "storeAs": "newLicenseeCode",
+      "description": "2-character licensee code (used when old licensee code = 0x33)"
+    },
+    {
+      "type": "field",
+      "name": "SGB Flag",
+      "offset": 326,
+      "length": 1,
+      "color": "#C7CEEA",
+      "opacity": 0.3,
+      "valueType": "uint8",
+      "storeAs": "sgbFlag",
+      "description": "0x03=Super Game Boy functions supported, 0x00=no SGB"
+    },
+    {
+      "type": "field",
+      "name": "Cartridge Type",
+      "offset": 327,
+      "length": 1,
+      "color": "#FFE66D",
+      "opacity": 0.3,
+      "valueType": "uint8",
+      "storeAs": "cartridgeType",
+      "description": "Memory Bank Controller type and features",
+      "valueMap": {
+        "0": "ROM Only",
+        "1": "MBC1",
+        "2": "MBC1+RAM",
+        "3": "MBC1+RAM+Battery",
+        "5": "MBC2",
+        "6": "MBC2+Battery",
+        "15": "MBC3+Timer+Battery",
+        "16": "MBC3+Timer+RAM+Battery",
+        "17": "MBC3",
+        "18": "MBC3+RAM",
+        "19": "MBC3+RAM+Battery",
+        "25": "MBC5",
+        "26": "MBC5+RAM",
+        "27": "MBC5+RAM+Battery",
+        "28": "MBC5+Rumble",
+        "29": "MBC5+Rumble+RAM",
+        "30": "MBC5+Rumble+RAM+Battery",
+        "32": "MBC6",
+        "34": "MBC7+Sensor+Rumble+RAM+Battery",
+        "252": "Pocket Camera",
+        "253": "Bandai TAMA5",
+        "254": "HuC3",
+        "255": "HuC1+RAM+Battery"
+      }
+    },
+    {
+      "type": "field",
+      "name": "ROM Size",
+      "offset": 328,
+      "length": 1,
+      "color": "#95E1D3",
+      "opacity": 0.3,
+      "valueType": "uint8",
+      "storeAs": "romSize",
+      "description": "ROM size code (actual size = 32KB << value)",
+      "valueMap": {
+        "0": "32KB (2 banks)",
+        "1": "64KB (4 banks)",
+        "2": "128KB (8 banks)",
+        "3": "256KB (16 banks)",
+        "4": "512KB (32 banks)",
+        "5": "1MB (64 banks)",
+        "6": "2MB (128 banks)",
+        "7": "4MB (256 banks)",
+        "8": "8MB (512 banks)"
+      },
+      "validationRules": {
+        "min": 0,
+        "max": 8
+      }
+    },
+    {
+      "type": "field",
+      "name": "RAM Size",
+      "offset": 329,
+      "length": 1,
+      "color": "#95E1D3",
+      "opacity": 0.3,
+      "valueType": "uint8",
+      "storeAs": "ramSize",
+      "description": "External RAM size code",
+      "valueMap": {
+        "0": "None",
+        "1": "Unused",
+        "2": "8KB (1 bank)",
+        "3": "32KB (4 banks)",
+        "4": "128KB (16 banks)",
+        "5": "64KB (8 banks)"
+      },
+      "validationRules": {
+        "min": 0,
+        "max": 5
+      }
+    },
+    {
+      "type": "field",
+      "name": "Destination Code",
+      "offset": 330,
+      "length": 1,
+      "color": "#C7CEEA",
+      "opacity": 0.3,
+      "valueType": "uint8",
+      "storeAs": "destinationCode",
+      "description": "0x00=Japan, 0x01=International (non-Japan)",
+      "valueMap": {
+        "0": "Japan",
+        "1": "International (non-Japan)"
+      },
+      "validationRules": {
+        "allowedValues": [0, 1]
+      }
+    },
+    {
+      "type": "field",
+      "name": "Old Licensee Code",
+      "offset": 331,
+      "length": 1,
+      "color": "#C7CEEA",
+      "opacity": 0.3,
+      "valueType": "uint8",
+      "storeAs": "oldLicenseeCode",
+      "description": "Old licensee code (0x33 = use new licensee code at 0x144)"
+    },
+    {
+      "type": "field",
+      "name": "Mask ROM Version",
+      "offset": 332,
+      "length": 1,
+      "color": "#C7CEEA",
+      "opacity": 0.3,
+      "valueType": "uint8",
+      "storeAs": "maskRomVersion",
+      "description": "Game revision number (usually 0x00)"
+    },
+    {
+      "type": "field",
+      "name": "Header Checksum",
+      "offset": 333,
+      "length": 1,
+      "color": "#FF6B9D",
+      "opacity": 0.3,
+      "valueType": "uint8",
+      "storeAs": "headerChecksum",
+      "description": "8-bit checksum: x=0; for i=0x134..0x14C: x=x-mem[i]-1; lower 8 bits"
+    },
+    {
+      "type": "field",
+      "name": "Global Checksum",
+      "offset": 334,
+      "length": 2,
+      "color": "#FF6B9D",
+      "opacity": 0.3,
+      "valueType": "uint16",
+      "storeAs": "globalChecksum",
+      "description": "16-bit big-endian sum of all ROM bytes except 0x14E-0x14F (not verified by hardware)"
+    },
+    {
+      "type": "metadata",
+      "name": "Format",
+      "variable": "title",
+      "description": "Game Title"
+    },
+    {
+      "type": "metadata",
+      "name": "CGB Mode",
+      "variable": "cgbFlag",
+      "description": "CGB Compatibility Flag"
+    }
+  ],
+  "assertions": [
+    {
+      "name": "Nintendo Logo signature valid",
+      "expression": "nintendoLogo[0..4] == 0xCEED6666",
+      "severity": "error",
+      "message": "Nintendo Logo at offset 0x104 must start with bytes CE ED 66 66"
+    },
+    {
+      "name": "CGB flag indicates Game Boy Color",
+      "expression": "cgbFlag == 128 || cgbFlag == 192",
+      "severity": "warning",
+      "message": "CGB flag is 0x00 (DMG only, not a GBC ROM); expected 0x80 (compatible) or 0xC0 (GBC only)"
+    },
+    {
+      "name": "Cartridge type is recognized MBC",
+      "expression": "cartridgeType <= 34 || cartridgeType >= 252",
+      "severity": "warning",
+      "message": "Cartridge type value does not match a known Memory Bank Controller type"
+    },
+    {
+      "name": "ROM size code within valid range",
+      "expression": "romSize >= 0 && romSize <= 8",
+      "severity": "error",
+      "message": "ROM size code must be 0-8 (32KB to 8MB)"
+    }
+  ],
+  "inspector": {
+    "badge": "title",
+    "primaryField": "cgbFlag",
+    "showQualityScore": true,
+    "groups": [
+      {
+        "title": "Game Identity",
+        "icon": "game",
+        "fields": [
+          "title",
+          "manufacturerCode",
+          "cgbFlag",
+          "destinationCode"
+        ]
+      },
+      {
+        "title": "Cartridge Hardware",
+        "icon": "chip",
+        "fields": [
+          "cartridgeType",
+          "romSize",
+          "ramSize",
+          "sgbFlag"
+        ]
+      },
+      {
+        "title": "Licensing",
+        "icon": "info",
+        "fields": [
+          "newLicenseeCode",
+          "oldLicenseeCode",
+          "maskRomVersion"
+        ]
+      },
+      {
+        "title": "Verification",
+        "icon": "checksum",
+        "fields": [
+          "entryPoint",
+          "nintendoLogo",
+          "headerChecksum",
+          "globalChecksum"
+        ]
+      }
+    ]
+  },
+  "exportTemplates": [
+    {
+      "name": "GBC Header (JSON)",
+      "format": "json",
+      "fields": [
+        "title",
+        "manufacturerCode",
+        "cgbFlag",
+        "cartridgeType",
+        "romSize",
+        "ramSize",
+        "destinationCode",
+        "headerChecksum",
+        "globalChecksum"
+      ]
+    },
+    {
+      "name": "GBC Summary (CSV)",
+      "format": "csv",
+      "fields": [
+        "title",
+        "cgbFlag",
+        "cartridgeType",
+        "romSize",
+        "ramSize",
+        "destinationCode"
+      ]
+    }
+  ],
+  "navigation": {
+    "bookmarks": [
+      {
+        "name": "Entry Point",
+        "offset": 256,
+        "icon": "code"
+      },
+      {
+        "name": "Nintendo Logo",
+        "offset": 260,
+        "icon": "signature"
+      },
+      {
+        "name": "Game Title",
+        "offset": 308,
+        "icon": "text"
+      },
+      {
+        "name": "CGB Flag",
+        "offset": 323,
+        "icon": "flag"
+      },
+      {
+        "name": "Cartridge Type",
+        "offset": 327,
+        "icon": "chip"
+      },
+      {
+        "name": "Header Checksum",
+        "offset": 333,
+        "icon": "checksum"
+      }
+    ]
+  },
+  "software": [
+    "BGB (GBC emulator and debugger)",
+    "Gambatte (accurate GBC emulator)",
+    "mGBA (multi-platform GB/GBC/GBA emulator)",
+    "SameBoy (accurate GB/GBC emulator)",
+    "RGBDS (Game Boy assembler toolchain)"
+  ],
+  "formatRelationships": {
+    "category": "Game",
+    "extensions": [
+      ".gbc"
+    ],
+    "relatedFormats": [
+      "ROM_GB"
+    ]
+  },
+  "MimeTypes": [
+    "application/x-gameboy-color-rom"
+  ],
+  "Software": [
+    "BGB (GBC emulator and debugger)",
+    "Gambatte (accurate GBC emulator)",
+    "mGBA (multi-platform GB/GBC/GBA emulator)",
+    "SameBoy (accurate GB/GBC emulator)",
+    "RGBDS (Game Boy assembler toolchain)"
+  ],
+  "UseCases": [
+    "GBC game emulation and testing",
+    "ROM hacking (Pokemon Crystal, Zelda DX, etc.)",
+    "Homebrew development with RGBDS toolchain",
+    "Game preservation and archival"
+  ],
+  "QualityMetrics": {
+    "CompletenessScore": 92,
+    "DocumentationLevel": "detailed",
+    "BlocksDefined": 17,
+    "ValidationRules": 4,
+    "LastUpdated": "2026-04-14",
+    "PriorityFormat": true,
+    "AutoRefined": false
+  },
+  "TechnicalDetails": {
+    "endianness": "little",
+    "processor": "Sharp LR35902 (Z80-like) at 4.19MHz normal / 8.39MHz double-speed (GBC)",
+    "memoryMap": "32KB ROM (0x0000-0x7FFF) + switchable banks via MBC; 8KB VRAM (2 banks GBC); 8KB WRAM (8 banks GBC)",
+    "display": "160x144 pixels, up to 56 colors on screen simultaneously (GBC palette)",
+    "gbcEnhancements": "Double-speed CPU mode, extra VRAM bank, 7 extra WRAM banks, DMA improvements, infrared communication",
+    "bootValidation": "Nintendo Logo at 0x104 is checked by boot ROM — invalid logo = cartridge rejected by hardware",
+    "checksumAlgorithm": "Header: x=0; for i=0x134..0x14C: x=x-mem[i]-1. Global: 16-bit BE sum of all bytes except 0x14E-0x14F",
+    "mbcBanking": "MBC1/MBC3/MBC5 provide ROM banking (up to 8MB) and optional RAM banking with battery backup"
+  },
+  "forensic": {
+    "category": "game",
+    "riskLevel": "low",
+    "suspiciousPatterns": [
+      {
+        "name": "Invalid Nintendo Logo",
+        "description": "Nintendo Logo bytes at 0x104 do not match expected values, indicating a homebrew or corrupted ROM",
+        "condition": "nintendoLogo[0..4] != 0xCEED6666"
+      },
+      {
+        "name": "Header checksum mismatch",
+        "description": "Header checksum at 0x14D does not match computed value over 0x134-0x14C, indicating modification",
+        "condition": "headerChecksum == 0"
+      }
+    ]
+  },
+  "aiHints": {
+    "analysisContext": "Game Boy Color ROM cartridge with Sharp LR35902 CPU, MBC memory banking, and hardware boot ROM validation",
+    "suggestedInspections": [
+      "Verify Nintendo Logo at offset 0x104 matches the fixed 48-byte bitmap (first 4 bytes: CE ED 66 66)",
+      "Check CGB flag at 0x143 to confirm GBC compatibility (0x80=compatible, 0xC0=GBC only)",
+      "Validate cartridge type byte against known MBC types to determine banking and feature support",
+      "Inspect ROM/RAM size codes and verify actual file size matches expected ROM size (32KB << romSize)",
+      "Compute header checksum over bytes 0x134-0x14C and compare with stored value at 0x14D",
+      "Examine entry point at 0x100 for expected NOP+JP pattern (00 C3 50 01)"
+    ]
+  },
+  "functions": {
+    "readUInt8": "Read 8-bit header fields (flags, checksums, size codes)",
+    "readUInt16BE": "Read big-endian 16-bit global checksum",
+    "extractASCIIString": "Read game title and licensee codes"
+  }
+}

--- a/Sources/Core/WpfHexEditor.Core.Definitions/FormatDefinitions/Game/ROM_NDS.whfmt
+++ b/Sources/Core/WpfHexEditor.Core.Definitions/FormatDefinitions/Game/ROM_NDS.whfmt
@@ -1,0 +1,638 @@
+{
+  "diffMode": "binary",
+  "formatName": "Nintendo DS ROM",
+  "version": "1.0",
+  "extensions": [
+    ".nds"
+  ],
+  "description": "Nintendo DS ROM images (.nds) contain full cartridge data for the NDS handheld (2004) with dual-CPU ARM9/ARM7 architecture and NitroFS filesystem",
+  "category": "Game",
+  "author": "WPFHexaEditor Team",
+  "preferredEditor": "hex-editor",
+  "references": {
+    "specifications": [
+      "GBATEK - NDS Technical Specification",
+      "Nintendo DS Cartridge Header Format",
+      "NDS ROM Header Documentation"
+    ],
+    "WebLinks": [
+      "http://problemkaputt.de/gbatek.htm#dscartridgeheader",
+      "https://dsibrew.org/wiki/NDS_Format",
+      "https://en.wikipedia.org/wiki/Nintendo_DS",
+      "https://www.romhacking.net/documents/nds/"
+    ]
+  },
+  "detection": {
+    "required": true,
+    "validation": {
+      "minFileSize": 512,
+      "maxSignatureOffset": 200
+    },
+    "signatures": [
+      {
+        "value": "24FFAE51",
+        "offset": 192,
+        "label": "Nintendo DS Logo data start at offset 0xC0 (identical across all licensed NDS ROMs)",
+        "weight": 1.0
+      }
+    ],
+    "matchMode": "any",
+    "MinimumScore": 1.0,
+    "Strength": "Strong",
+    "EntropyHint": {
+      "min": 3.0,
+      "max": 7.0
+    }
+  },
+  "variables": {
+    "currentOffset": 0,
+    "gameTitle": "",
+    "gameCode": "",
+    "makerCode": "",
+    "unitCode": 0,
+    "encryptionSeedSelect": 0,
+    "deviceCapacity": 0,
+    "ndsRegion": 0,
+    "romVersion": 0,
+    "autostart": 0,
+    "arm9RomOffset": 0,
+    "arm9EntryAddress": 0,
+    "arm9RamAddress": 0,
+    "arm9Size": 0,
+    "arm7RomOffset": 0,
+    "arm7EntryAddress": 0,
+    "arm7RamAddress": 0,
+    "arm7Size": 0,
+    "fntOffset": 0,
+    "fntSize": 0,
+    "fatOffset": 0,
+    "fatSize": 0,
+    "iconTitleOffset": 0,
+    "romSize": 0,
+    "headerSize": 0,
+    "nintendoLogo": "",
+    "logoChecksum": 0,
+    "headerChecksum": 0
+  },
+  "blocks": [
+    {
+      "type": "field",
+      "name": "Game Title",
+      "offset": 0,
+      "length": 12,
+      "color": "#4ECDC4",
+      "opacity": 0.3,
+      "valueType": "ascii",
+      "storeAs": "gameTitle",
+      "description": "Game title in ASCII (null-padded, e.g. 'POKEMON D')"
+    },
+    {
+      "type": "field",
+      "name": "Game Code",
+      "offset": 12,
+      "length": 4,
+      "color": "#FFE66D",
+      "opacity": 0.3,
+      "valueType": "ascii",
+      "storeAs": "gameCode",
+      "description": "4-character game code (e.g. 'ADAE' = Pokemon Diamond US)"
+    },
+    {
+      "type": "field",
+      "name": "Maker Code",
+      "offset": 16,
+      "length": 2,
+      "color": "#C7CEEA",
+      "opacity": 0.3,
+      "valueType": "ascii",
+      "storeAs": "makerCode",
+      "description": "2-character maker code (e.g. '01' = Nintendo)"
+    },
+    {
+      "type": "field",
+      "name": "Unit Code",
+      "offset": 18,
+      "length": 1,
+      "color": "#FFE66D",
+      "opacity": 0.3,
+      "valueType": "uint8",
+      "storeAs": "unitCode",
+      "description": "0x00=NDS, 0x02=NDS+DSi, 0x03=DSi only",
+      "valueMap": {
+        "0": "Nintendo DS",
+        "2": "NDS + DSi Enhanced",
+        "3": "DSi Exclusive"
+      },
+      "validationRules": {
+        "allowedValues": [0, 2, 3]
+      }
+    },
+    {
+      "type": "field",
+      "name": "Encryption Seed Select",
+      "offset": 19,
+      "length": 1,
+      "color": "#C7CEEA",
+      "opacity": 0.3,
+      "valueType": "uint8",
+      "storeAs": "encryptionSeedSelect",
+      "description": "Encryption seed index for Secure Area"
+    },
+    {
+      "type": "field",
+      "name": "Device Capacity",
+      "offset": 20,
+      "length": 1,
+      "color": "#95E1D3",
+      "opacity": 0.3,
+      "valueType": "uint8",
+      "storeAs": "deviceCapacity",
+      "description": "Cartridge size = 128KB << value"
+    },
+    {
+      "type": "field",
+      "name": "NDS Region",
+      "offset": 30,
+      "length": 1,
+      "color": "#C7CEEA",
+      "opacity": 0.3,
+      "valueType": "uint8",
+      "storeAs": "ndsRegion",
+      "description": "Region byte (0x00 = normal)"
+    },
+    {
+      "type": "field",
+      "name": "ROM Version",
+      "offset": 31,
+      "length": 1,
+      "color": "#C7CEEA",
+      "opacity": 0.3,
+      "valueType": "uint8",
+      "storeAs": "romVersion",
+      "description": "Game revision number"
+    },
+    {
+      "type": "field",
+      "name": "Autostart",
+      "offset": 32,
+      "length": 1,
+      "color": "#C7CEEA",
+      "opacity": 0.3,
+      "valueType": "uint8",
+      "storeAs": "autostart",
+      "description": "Bit 2: skip health/safety screen"
+    },
+    {
+      "type": "field",
+      "name": "ARM9 ROM Offset",
+      "offset": 36,
+      "length": 4,
+      "color": "#6C5CE7",
+      "opacity": 0.3,
+      "valueType": "uint32",
+      "storeAs": "arm9RomOffset",
+      "description": "ARM9 binary offset within the ROM file"
+    },
+    {
+      "type": "field",
+      "name": "ARM9 Entry Address",
+      "offset": 40,
+      "length": 4,
+      "color": "#6C5CE7",
+      "opacity": 0.3,
+      "valueType": "uint32",
+      "storeAs": "arm9EntryAddress",
+      "description": "ARM9 entry point address in RAM"
+    },
+    {
+      "type": "field",
+      "name": "ARM9 RAM Address",
+      "offset": 44,
+      "length": 4,
+      "color": "#6C5CE7",
+      "opacity": 0.3,
+      "valueType": "uint32",
+      "storeAs": "arm9RamAddress",
+      "description": "ARM9 load address in RAM"
+    },
+    {
+      "type": "field",
+      "name": "ARM9 Size",
+      "offset": 48,
+      "length": 4,
+      "color": "#6C5CE7",
+      "opacity": 0.3,
+      "valueType": "uint32",
+      "storeAs": "arm9Size",
+      "description": "ARM9 binary size in bytes"
+    },
+    {
+      "type": "field",
+      "name": "ARM7 ROM Offset",
+      "offset": 52,
+      "length": 4,
+      "color": "#E17055",
+      "opacity": 0.3,
+      "valueType": "uint32",
+      "storeAs": "arm7RomOffset",
+      "description": "ARM7 binary offset within the ROM file"
+    },
+    {
+      "type": "field",
+      "name": "ARM7 Entry Address",
+      "offset": 56,
+      "length": 4,
+      "color": "#E17055",
+      "opacity": 0.3,
+      "valueType": "uint32",
+      "storeAs": "arm7EntryAddress",
+      "description": "ARM7 entry point address in RAM"
+    },
+    {
+      "type": "field",
+      "name": "ARM7 RAM Address",
+      "offset": 60,
+      "length": 4,
+      "color": "#E17055",
+      "opacity": 0.3,
+      "valueType": "uint32",
+      "storeAs": "arm7RamAddress",
+      "description": "ARM7 load address in RAM"
+    },
+    {
+      "type": "field",
+      "name": "ARM7 Size",
+      "offset": 64,
+      "length": 4,
+      "color": "#E17055",
+      "opacity": 0.3,
+      "valueType": "uint32",
+      "storeAs": "arm7Size",
+      "description": "ARM7 binary size in bytes"
+    },
+    {
+      "type": "field",
+      "name": "FNT Offset",
+      "offset": 68,
+      "length": 4,
+      "color": "#00B894",
+      "opacity": 0.3,
+      "valueType": "uint32",
+      "storeAs": "fntOffset",
+      "description": "File Name Table offset in ROM"
+    },
+    {
+      "type": "field",
+      "name": "FNT Size",
+      "offset": 72,
+      "length": 4,
+      "color": "#00B894",
+      "opacity": 0.3,
+      "valueType": "uint32",
+      "storeAs": "fntSize",
+      "description": "File Name Table size in bytes"
+    },
+    {
+      "type": "field",
+      "name": "FAT Offset",
+      "offset": 76,
+      "length": 4,
+      "color": "#00B894",
+      "opacity": 0.3,
+      "valueType": "uint32",
+      "storeAs": "fatOffset",
+      "description": "File Allocation Table offset in ROM"
+    },
+    {
+      "type": "field",
+      "name": "FAT Size",
+      "offset": 80,
+      "length": 4,
+      "color": "#00B894",
+      "opacity": 0.3,
+      "valueType": "uint32",
+      "storeAs": "fatSize",
+      "description": "File Allocation Table size in bytes"
+    },
+    {
+      "type": "field",
+      "name": "Icon/Title Offset",
+      "offset": 104,
+      "length": 4,
+      "color": "#FDCB6E",
+      "opacity": 0.3,
+      "valueType": "uint32",
+      "storeAs": "iconTitleOffset",
+      "description": "Offset to icon/title banner data (32x32 icon + titles in 6 languages)"
+    },
+    {
+      "type": "field",
+      "name": "ROM Size",
+      "offset": 128,
+      "length": 4,
+      "color": "#FF6B9D",
+      "opacity": 0.3,
+      "valueType": "uint32",
+      "storeAs": "romSize",
+      "description": "Used ROM size in bytes (may differ from actual file size)"
+    },
+    {
+      "type": "field",
+      "name": "Header Size",
+      "offset": 132,
+      "length": 4,
+      "color": "#C7CEEA",
+      "opacity": 0.3,
+      "valueType": "uint32",
+      "storeAs": "headerSize",
+      "description": "Header size (0x4000 = 16KB including secure area)"
+    },
+    {
+      "type": "signature",
+      "name": "Nintendo Logo",
+      "offset": 192,
+      "length": 156,
+      "color": "#FF6B6B",
+      "opacity": 0.4,
+      "description": "Compressed Nintendo bitmap (156 bytes, identical across all licensed NDS cartridges)",
+      "storeAs": "nintendoLogo",
+      "valueType": "bytes"
+    },
+    {
+      "type": "field",
+      "name": "Logo Checksum",
+      "offset": 348,
+      "length": 2,
+      "color": "#FF6B9D",
+      "opacity": 0.3,
+      "valueType": "uint16",
+      "storeAs": "logoChecksum",
+      "description": "CRC-16 of Nintendo Logo data"
+    },
+    {
+      "type": "field",
+      "name": "Header Checksum",
+      "offset": 350,
+      "length": 2,
+      "color": "#FF6B9D",
+      "opacity": 0.3,
+      "valueType": "uint16",
+      "storeAs": "headerChecksum",
+      "description": "CRC-16 of header bytes 0x000-0x15D"
+    },
+    {
+      "type": "metadata",
+      "name": "Format",
+      "variable": "gameTitle",
+      "description": "Game Title"
+    },
+    {
+      "type": "metadata",
+      "name": "Game Code",
+      "variable": "gameCode",
+      "description": "Game Code"
+    }
+  ],
+  "assertions": [
+    {
+      "name": "Nintendo Logo signature valid",
+      "expression": "nintendoLogo[0..4] == 0x24FFAE51",
+      "severity": "error",
+      "message": "Nintendo DS Logo at offset 0xC0 must start with bytes 24 FF AE 51"
+    },
+    {
+      "name": "Unit code within valid range",
+      "expression": "unitCode == 0 || unitCode == 2 || unitCode == 3",
+      "severity": "error",
+      "message": "Unit code must be 0x00 (NDS), 0x02 (NDS+DSi), or 0x03 (DSi only)"
+    },
+    {
+      "name": "ARM9 binary size is valid",
+      "expression": "arm9Size > 0 && arm9Size < 4194304",
+      "severity": "error",
+      "message": "ARM9 binary size must be > 0 and < 4MB (0x400000)"
+    },
+    {
+      "name": "ARM7 binary size is non-zero",
+      "expression": "arm7Size > 0",
+      "severity": "error",
+      "message": "ARM7 binary size must be greater than zero"
+    },
+    {
+      "name": "Header checksum coverage note",
+      "expression": "headerChecksum > 0",
+      "severity": "warning",
+      "message": "Header checksum (CRC-16) at 0x15E covers bytes 0x000-0x15D; verify manually if needed"
+    }
+  ],
+  "inspector": {
+    "badge": "gameTitle",
+    "primaryField": "gameCode",
+    "showQualityScore": true,
+    "groups": [
+      {
+        "title": "Game Identity",
+        "icon": "game",
+        "fields": [
+          "gameTitle",
+          "gameCode",
+          "makerCode",
+          "unitCode",
+          "romVersion"
+        ]
+      },
+      {
+        "title": "ARM9 Processor",
+        "icon": "cpu",
+        "fields": [
+          "arm9RomOffset",
+          "arm9EntryAddress",
+          "arm9RamAddress",
+          "arm9Size"
+        ]
+      },
+      {
+        "title": "ARM7 Processor",
+        "icon": "cpu",
+        "fields": [
+          "arm7RomOffset",
+          "arm7EntryAddress",
+          "arm7RamAddress",
+          "arm7Size"
+        ]
+      },
+      {
+        "title": "NitroFS Filesystem",
+        "icon": "folder",
+        "fields": [
+          "fntOffset",
+          "fntSize",
+          "fatOffset",
+          "fatSize"
+        ]
+      },
+      {
+        "title": "ROM Metadata",
+        "icon": "info",
+        "fields": [
+          "romSize",
+          "headerSize",
+          "deviceCapacity",
+          "iconTitleOffset"
+        ]
+      },
+      {
+        "title": "Checksums",
+        "icon": "checksum",
+        "fields": [
+          "logoChecksum",
+          "headerChecksum"
+        ]
+      }
+    ]
+  },
+  "exportTemplates": [
+    {
+      "name": "NDS Header (JSON)",
+      "format": "json",
+      "fields": [
+        "gameTitle",
+        "gameCode",
+        "makerCode",
+        "unitCode",
+        "arm9RomOffset",
+        "arm9Size",
+        "arm7RomOffset",
+        "arm7Size",
+        "romSize",
+        "headerChecksum"
+      ]
+    },
+    {
+      "name": "NDS Summary (CSV)",
+      "format": "csv",
+      "fields": [
+        "gameTitle",
+        "gameCode",
+        "makerCode",
+        "unitCode",
+        "deviceCapacity",
+        "romSize",
+        "arm9Size",
+        "arm7Size"
+      ]
+    }
+  ],
+  "navigation": {
+    "bookmarks": [
+      {
+        "name": "Game Title",
+        "offset": 0,
+        "icon": "text"
+      },
+      {
+        "name": "ARM9 Code Info",
+        "offset": 36,
+        "icon": "cpu"
+      },
+      {
+        "name": "ARM7 Code Info",
+        "offset": 52,
+        "icon": "cpu"
+      },
+      {
+        "name": "NitroFS Tables",
+        "offset": 68,
+        "icon": "folder"
+      },
+      {
+        "name": "Nintendo Logo",
+        "offset": 192,
+        "icon": "signature"
+      },
+      {
+        "name": "Header Checksum",
+        "offset": 350,
+        "icon": "checksum"
+      }
+    ]
+  },
+  "software": [
+    "DeSmuME (NDS emulator)",
+    "melonDS (NDS emulator)",
+    "no$gba (NDS/GBA emulator and debugger)",
+    "NDSTool (ROM extract/rebuild utility)",
+    "CrystalTile2 (NDS ROM editor)"
+  ],
+  "formatRelationships": {
+    "category": "Game",
+    "extensions": [
+      ".nds"
+    ],
+    "relatedFormats": [
+      "ROM_3DS",
+      "ROM_GBA"
+    ]
+  },
+  "MimeTypes": [
+    "application/x-nintendo-ds-rom"
+  ],
+  "Software": [
+    "DeSmuME (NDS emulator)",
+    "melonDS (NDS emulator)",
+    "no$gba (NDS/GBA emulator and debugger)",
+    "NDSTool (ROM extract/rebuild utility)",
+    "CrystalTile2 (NDS ROM editor)"
+  ],
+  "UseCases": [
+    "NDS game emulation and testing",
+    "ROM hacking and fan translations",
+    "NDS homebrew development",
+    "Game preservation and archival"
+  ],
+  "QualityMetrics": {
+    "CompletenessScore": 90,
+    "DocumentationLevel": "detailed",
+    "BlocksDefined": 29,
+    "ValidationRules": 5,
+    "LastUpdated": "2026-04-14",
+    "PriorityFormat": true,
+    "AutoRefined": false
+  },
+  "TechnicalDetails": {
+    "endianness": "little",
+    "dualCPU": "ARM9 (main, 67MHz) + ARM7 (sub, 33MHz for sound/WiFi/touchscreen)",
+    "filesystem": "NitroFS — File Name Table (FNT) + File Allocation Table (FAT)",
+    "overlays": "ARM9/ARM7 overlay tables for dynamic code loading",
+    "secureArea": "Bytes 0x4000-0x7FFF encrypted with Blowfish (required for DS hardware boot)",
+    "banner": "Icon/Title at iconTitleOffset: 32x32 icon bitmap + titles in 6 languages (JP/EN/FR/DE/IT/ES)",
+    "headerSize": "4096 bytes (0x1000) logical header; 16KB (0x4000) including secure area padding"
+  },
+  "forensic": {
+    "category": "game",
+    "riskLevel": "low",
+    "suspiciousPatterns": [
+      {
+        "name": "Secure area decrypted",
+        "description": "Secure Area (0x4000-0x7FFF) may be decrypted in dumped ROMs, indicating a modified or homebrew cartridge",
+        "condition": "arm9RomOffset == 0x4000"
+      }
+    ]
+  },
+  "aiHints": {
+    "analysisContext": "Nintendo DS ROM cartridge with dual-CPU ARM9/ARM7 architecture, NitroFS filesystem, and Blowfish-encrypted secure area",
+    "suggestedInspections": [
+      "Verify Nintendo Logo at offset 0xC0 matches the fixed 156-byte bitmap (first 4 bytes: 24 FF AE 51)",
+      "Validate ARM9 and ARM7 ROM offsets point within file bounds and sizes are reasonable",
+      "Check FNT/FAT table offsets and sizes for NitroFS filesystem integrity",
+      "Inspect unit code to determine NDS/DSi compatibility mode",
+      "Verify CRC-16 header checksum at 0x15E against computed value over bytes 0x000-0x15D",
+      "Examine icon/title banner offset for game metadata extraction"
+    ]
+  },
+  "functions": {
+    "readUInt32LE": "Read little-endian 32-bit header fields",
+    "readUInt16LE": "Read little-endian 16-bit checksums",
+    "extractASCIIString": "Read game title and codes"
+  }
+}

--- a/Sources/Core/WpfHexEditor.Core.Definitions/FormatDefinitions/MachineLearning/ONNX.whfmt
+++ b/Sources/Core/WpfHexEditor.Core.Definitions/FormatDefinitions/MachineLearning/ONNX.whfmt
@@ -1,0 +1,257 @@
+{
+  "diffMode": "binary",
+  "formatName": "ONNX (Open Neural Network Exchange)",
+  "version": "1.0",
+  "extensions": [ ".onnx" ],
+  "description": "Open Neural Network Exchange model file using Protocol Buffers serialization for cross-framework ML model interoperability between PyTorch, TensorFlow, and inference runtimes.",
+  "category": "MachineLearning",
+  "author": "WPFHexaEditor Team",
+  "preferredEditor": "hex-editor",
+  "MimeTypes": [ "application/octet-stream", "application/x-onnx" ],
+
+  "UseCases": [
+    "Cross-framework ML model interchange between PyTorch, TensorFlow, and other training frameworks",
+    "Optimized inference deployment via ONNX Runtime, TensorRT, and OpenVINO",
+    "Edge AI and mobile inference with model quantization and optimization",
+    "Model validation, visualization, and architecture inspection with Netron"
+  ],
+
+  "software": [
+    { "name": "ONNX Runtime",       "role": "consumer" },
+    { "name": "Netron",             "role": "consumer" },
+    { "name": "PyTorch (torch.onnx.export)", "role": "producer" },
+    { "name": "tf2onnx",            "role": "producer" },
+    { "name": "TensorRT",           "role": "consumer" },
+    { "name": "OpenVINO",           "role": "consumer" },
+    { "name": "onnxruntime-web",    "role": "consumer" }
+  ],
+
+  "formatRelationships": {
+    "relatedFormats": [ "TFLITE", "SAFETENSORS", "PYTORCH", "TorchScript" ],
+    "container": null,
+    "notes": "ONNX files are Protocol Buffers-serialized ModelProto messages. The format is defined by the ONNX spec and uses protobuf wire format encoding, meaning there are no fixed magic bytes — detection relies on extension and heuristic analysis of the first protobuf tag byte."
+  },
+
+  "references": {
+    "specifications": [
+      "ONNX IR Specification (github.com/onnx/onnx/blob/main/docs/IR.md)",
+      "ONNX Operators (github.com/onnx/onnx/blob/main/docs/Operators.md)"
+    ],
+    "WebLinks": [
+      "https://onnx.ai/",
+      "https://en.wikipedia.org/wiki/Open_Neural_Network_Exchange"
+    ]
+  },
+
+  "detection": {
+    "signatures": [
+      {
+        "value": "08",
+        "offset": 0,
+        "label": "Protobuf field 1 tag (ir_version varint) — common ONNX start byte",
+        "weight": 30,
+        "required": false
+      }
+    ],
+    "matchMode": "weighted",
+    "MinimumScore": 30,
+    "Strength": "Weak",
+    "EntropyHint": {
+      "min": 4.0,
+      "max": 7.5,
+      "note": "Model weights (initializer tensors) are high entropy; protobuf structural metadata and operator names have moderate entropy around 4.0-5.5."
+    },
+    "validation": {
+      "minFileSize": 8,
+      "maxSignatureOffset": 0
+    }
+  },
+
+  "variables": {
+    "protobufTag":   { "offset": 0, "length": 1, "type": "uint8" },
+    "irVersion":     { "offset": 1, "length": 1, "type": "uint8" },
+    "thirdByte":     { "offset": 2, "length": 1, "type": "uint8" }
+  },
+
+  "blocks": [
+    {
+      "type": "signature",
+      "name": "Protobuf Tag Byte",
+      "offset": 0,
+      "length": 1,
+      "color": "#FF6B6B",
+      "opacity": 0.9,
+      "description": "First protobuf tag byte; for ONNX ModelProto field 1 (ir_version) with wire type 0 (varint), this is 0x08. Other starting tags are possible if ir_version is omitted.",
+      "storeAs": "protobufTag",
+      "valueType": "uint8"
+    },
+    {
+      "type": "field",
+      "name": "IR Version",
+      "offset": 1,
+      "length": 1,
+      "color": "#4ECDC4",
+      "opacity": 0.8,
+      "description": "Varint-encoded ONNX Intermediate Representation version; common values: 3 (ONNX 1.2), 4 (ONNX 1.3), 5 (ONNX 1.4), 6 (ONNX 1.6), 7 (ONNX 1.7), 8 (ONNX 1.8), 9 (ONNX 1.14). Single-byte varint for values 1-127.",
+      "storeAs": "irVersion",
+      "valueType": "uint8",
+      "valueMap": {
+        "3": "ONNX IR v3 (ONNX 1.2)",
+        "4": "ONNX IR v4 (ONNX 1.3)",
+        "5": "ONNX IR v5 (ONNX 1.4)",
+        "6": "ONNX IR v6 (ONNX 1.6)",
+        "7": "ONNX IR v7 (ONNX 1.7)",
+        "8": "ONNX IR v8 (ONNX 1.8)",
+        "9": "ONNX IR v9 (ONNX 1.14)",
+        "10": "ONNX IR v10 (ONNX 1.15+)"
+      }
+    },
+    {
+      "type": "field",
+      "name": "Next Protobuf Tag",
+      "offset": 2,
+      "length": 1,
+      "color": "#45B7D1",
+      "opacity": 0.7,
+      "description": "Next protobuf field tag after ir_version; typically 0x12 (field 2, wire type 2 = length-delimited) for producer_name, or 0x42 (field 8, wire type 2) for opset_import.",
+      "storeAs": "thirdByte",
+      "valueType": "uint8"
+    },
+    {
+      "type": "metadata",
+      "name": "Producer Info",
+      "offset": "variable",
+      "length": "variable",
+      "color": "#96CEB4",
+      "opacity": 0.65,
+      "description": "Protobuf string fields for producer_name (field 2) and producer_version (field 3); common values include 'pytorch', 'tf2onnx', 'onnxruntime', 'onnxmltools'."
+    },
+    {
+      "type": "metadata",
+      "name": "Opset Import Table",
+      "offset": "variable",
+      "length": "variable",
+      "color": "#FFEAA7",
+      "opacity": 0.6,
+      "description": "Repeated opset_import messages (field 8) specifying operator set domain and version; default domain '' uses ONNX standard operators, 'ai.onnx.ml' for ML operators."
+    },
+    {
+      "type": "metadata",
+      "name": "Graph Definition",
+      "offset": "variable",
+      "length": "variable",
+      "color": "#DDA0DD",
+      "opacity": 0.55,
+      "description": "GraphProto message (field 7) containing the computation graph: node[] (operators), initializer[] (weight tensors), input[] and output[] (tensor type/shape), and doc_string."
+    }
+  ],
+
+  "assertions": [
+    {
+      "name": "ProtobufTagField1",
+      "expression": "protobufTag == 0x08",
+      "severity": "warning",
+      "message": "First byte is not 0x08 (protobuf field 1, varint wire type); this may not be a standard ONNX file or ir_version field may be absent."
+    },
+    {
+      "name": "IRVersionInRange",
+      "expression": "irVersion >= 1 && irVersion <= 15",
+      "severity": "warning",
+      "message": "IR version is outside expected range 1-15; the file may use an unrecognized ONNX specification version."
+    },
+    {
+      "name": "FileSizeMinimum",
+      "expression": "FILE_SIZE >= 32",
+      "severity": "error",
+      "message": "File is too small (< 32 bytes) to contain a valid ONNX model with graph definition."
+    },
+    {
+      "name": "FileSizeReasonable",
+      "expression": "FILE_SIZE >= 256",
+      "severity": "info",
+      "message": "File is very small for an ONNX model; typical models with weights are at least several kilobytes."
+    }
+  ],
+
+  "navigation": {
+    "bookmarks": [
+      { "name": "Protobuf Tag",    "offset": 0, "description": "First protobuf tag byte (0x08 for ir_version)" },
+      { "name": "IR Version",      "offset": 1, "description": "ONNX IR version (varint, typically 3-10)" },
+      { "name": "Next Field Tag",  "offset": 2, "description": "Second protobuf field tag (producer_name or opset_import)" }
+    ]
+  },
+
+  "inspector": {
+    "badge": "ONNX",
+    "primaryField": "irVersion",
+    "showQualityScore": true,
+    "groups": [
+      {
+        "name": "Protobuf Header",
+        "fields": [ "protobufTag", "irVersion", "thirdByte" ]
+      },
+      {
+        "name": "Model Metadata",
+        "fields": [ "irVersion" ]
+      }
+    ]
+  },
+
+  "exportTemplates": [
+    {
+      "name": "ONNX Header Summary",
+      "format": "text",
+      "template": "ONNX Model\n  Tag Byte       : 0x{protobufTag:X2}\n  IR Version     : {irVersion} ({irVersion_mapped})\n  Next Tag       : 0x{thirdByte:X2}"
+    },
+    {
+      "name": "ONNX JSON Report",
+      "format": "json",
+      "template": "{ \"format\": \"ONNX\", \"protobufTag\": {protobufTag}, \"irVersion\": {irVersion} }"
+    }
+  ],
+
+  "forensic": {
+    "category": "MachineLearningArtifact",
+    "riskLevel": "low",
+    "suspiciousPatterns": [
+      { "pattern": "UnusuallyLargeModel",       "description": "ONNX models over 2GB may indicate full-precision LLM weights or bloated unoptimized graphs." },
+      { "pattern": "CustomOperatorDomain",       "description": "Non-standard opset domain strings may indicate proprietary or experimental operators." },
+      { "pattern": "EmbeddedTrainingData",       "description": "Initializer tensors may inadvertently contain training data fragments or memorized samples." }
+    ]
+  },
+
+  "aiHints": {
+    "analysisContext": "ONNX files use Protocol Buffers wire format to serialize a ModelProto message. There are no fixed magic bytes; the first byte is typically 0x08 (protobuf field 1 tag for ir_version). The model contains a GraphProto with nodes (operators), initializer tensors (weights), and input/output tensor shape information. ONNX opset versions determine which operators are available.",
+    "suggestedInspections": [
+      "Check the ir_version varint at offset 1 to identify the ONNX specification version and supported operator set.",
+      "Scan for producer_name string (field 2) to identify the originating framework (pytorch, tf2onnx, onnxmltools, etc.).",
+      "Examine opset_import entries to verify operator set compatibility with the target inference runtime.",
+      "Look for custom_ops or non-standard domain strings that may require specialized runtime extensions.",
+      "Estimate model size by locating initializer tensor data regions, which contain the majority of file bytes.",
+      "Check for metadata_props entries that may contain training configuration, dataset info, or model card data."
+    ]
+  },
+
+  "TechnicalDetails": {
+    "specification": "ONNX specification: github.com/onnx/onnx/blob/main/docs/IR.md; Protocol Buffers schema: github.com/onnx/onnx/blob/main/onnx/onnx.proto",
+    "endianness": "protobuf-defined (varint encoding, little-endian for fixed-width fields)",
+    "serializationFormat": "Google Protocol Buffers (protobuf) wire format",
+    "modelStructure": {
+      "ModelProto": "Top-level container with ir_version, opset_import[], producer_name, producer_version, domain, model_version, doc_string, graph, metadata_props[]",
+      "GraphProto": "Computation graph with node[] (operators), initializer[] (weight tensors), input[], output[], value_info[]",
+      "NodeProto": "Single operator: op_type, input[], output[], attribute[], domain",
+      "TensorProto": "Tensor data: dims[], data_type, raw_data or typed arrays"
+    },
+    "notes": "ONNX models larger than 2GB require external data format where tensor data is stored in separate files alongside the .onnx protobuf file."
+  },
+
+  "QualityMetrics": {
+    "CompletenessScore": 88,
+    "DocumentationLevel": "comprehensive",
+    "BlocksDefined": 6,
+    "ValidationRules": 4,
+    "LastUpdated": "2026-04-14",
+    "PriorityFormat": true,
+    "AutoRefined": false
+  }
+}

--- a/Sources/Core/WpfHexEditor.Core.Definitions/FormatDefinitions/MachineLearning/PYTORCH.whfmt
+++ b/Sources/Core/WpfHexEditor.Core.Definitions/FormatDefinitions/MachineLearning/PYTORCH.whfmt
@@ -1,0 +1,292 @@
+{
+  "diffMode": "binary",
+  "formatName": "PyTorch Model (ZIP/Pickle)",
+  "version": "1.0",
+  "extensions": [ ".pt", ".pth", ".bin" ],
+  "description": "PyTorch serialized model checkpoint using ZIP container with pickled state dictionaries and raw tensor buffers; the pickle-based format allows arbitrary code execution on load, making untrusted files a serious security risk.",
+  "category": "MachineLearning",
+  "author": "WPFHexaEditor Team",
+  "preferredEditor": "hex-editor",
+  "MimeTypes": [ "application/zip", "application/octet-stream" ],
+
+  "UseCases": [
+    "PyTorch model checkpoint saving and resuming during training (optimizer state, epoch, loss)",
+    "Pre-trained model weight distribution for transfer learning and fine-tuning",
+    "Hugging Face model hub distribution (pre-safetensors era, many models still use .bin format)",
+    "Research model sharing and reproducibility across PyTorch-based ML pipelines"
+  ],
+
+  "software": [
+    { "name": "PyTorch (torch.save / torch.load)",  "role": "producer/consumer" },
+    { "name": "Netron",                             "role": "consumer" },
+    { "name": "fickling (pickle security scanner)",  "role": "consumer" },
+    { "name": "picklescan",                         "role": "consumer" },
+    { "name": "Hugging Face transformers",           "role": "consumer" }
+  ],
+
+  "formatRelationships": {
+    "relatedFormats": [ "SAFETENSORS", "ONNX", "TorchScript (.pt with JIT)", "ZIP" ],
+    "container": "ZIP (PK local file headers)",
+    "notes": "Modern PyTorch torch.save() produces ZIP archives containing archive/data.pkl (pickled state_dict) and archive/data/N (raw tensor buffers). Legacy format uses raw pickle stream starting with opcode 0x80. Migration path: convert to SafeTensors via safetensors.torch.save_file() to eliminate code execution risk."
+  },
+
+  "references": {
+    "specifications": [
+      "PyTorch Serialization (pytorch.org/docs/stable/notes/serialization.html)",
+      "Python Pickle Protocol (docs.python.org/3/library/pickle.html)"
+    ],
+    "WebLinks": [
+      "https://pytorch.org/docs/stable/generated/torch.save.html",
+      "https://en.wikipedia.org/wiki/PyTorch"
+    ]
+  },
+
+  "detection": {
+    "signatures": [
+      {
+        "value": "504B0304",
+        "offset": 0,
+        "label": "ZIP magic (PK\\x03\\x04) — PyTorch ZIP-serialized model",
+        "weight": 50,
+        "required": false
+      },
+      {
+        "value": "80",
+        "offset": 0,
+        "label": "Pickle protocol 2+ opcode (0x80) — legacy PyTorch torch.save format",
+        "weight": 30,
+        "required": false
+      }
+    ],
+    "matchMode": "any",
+    "MinimumScore": 30,
+    "Strength": "Medium",
+    "EntropyHint": {
+      "min": 5.0,
+      "max": 8.0,
+      "note": "ZIP-compressed pickle metadata has moderate entropy; raw tensor buffers (float32/float16/bfloat16 weights) approach entropy 7.5-8.0. ZIP-stored (uncompressed) tensor entries have similar entropy to raw weights."
+    },
+    "validation": {
+      "minFileSize": 16,
+      "maxSignatureOffset": 0
+    }
+  },
+
+  "variables": {
+    "magic":          { "offset": 0, "length": 4, "type": "uint32le" },
+    "zipVersion":     { "offset": 4, "length": 2, "type": "uint16le" },
+    "zipFlags":       { "offset": 6, "length": 2, "type": "uint16le" },
+    "zipCompression": { "offset": 8, "length": 2, "type": "uint16le" }
+  },
+
+  "blocks": [
+    {
+      "type": "signature",
+      "name": "ZIP / Pickle Magic",
+      "offset": 0,
+      "length": 4,
+      "color": "#FF6B6B",
+      "opacity": 0.9,
+      "description": "File format identifier: 0x504B0304 ('PK\\x03\\x04') for modern ZIP-serialized PyTorch models, or 0x80 (pickle PROTO opcode) followed by protocol version byte for legacy torch.save format.",
+      "storeAs": "magic",
+      "valueType": "uint32"
+    },
+    {
+      "type": "field",
+      "name": "ZIP Version Needed",
+      "offset": 4,
+      "length": 2,
+      "color": "#4ECDC4",
+      "opacity": 0.8,
+      "description": "ZIP minimum version needed to extract (ZIP format only); PyTorch typically uses version 20 (ZIP 2.0) for stored/deflated entries.",
+      "storeAs": "zipVersion",
+      "valueType": "uint16",
+      "endianness": "little"
+    },
+    {
+      "type": "field",
+      "name": "ZIP General Purpose Flags",
+      "offset": 6,
+      "length": 2,
+      "color": "#45B7D1",
+      "opacity": 0.75,
+      "description": "ZIP general purpose bit flags (ZIP format only); PyTorch models typically use 0x0000 (no encryption, no data descriptor).",
+      "storeAs": "zipFlags",
+      "valueType": "uint16",
+      "endianness": "little"
+    },
+    {
+      "type": "field",
+      "name": "ZIP Compression Method",
+      "offset": 8,
+      "length": 2,
+      "color": "#96CEB4",
+      "opacity": 0.7,
+      "description": "ZIP compression method: 0x00 (stored) for raw tensor buffers, 0x08 (deflate) for pickle data. PyTorch typically stores tensor data uncompressed for memory-mapped access.",
+      "storeAs": "zipCompression",
+      "valueType": "uint16",
+      "endianness": "little",
+      "valueMap": {
+        "0": "Stored (no compression)",
+        "8": "Deflate"
+      }
+    },
+    {
+      "type": "metadata",
+      "name": "ZIP Entry: archive/data.pkl",
+      "offset": "variable",
+      "length": "variable",
+      "color": "#FFEAA7",
+      "opacity": 0.65,
+      "description": "Pickled Python state_dict (OrderedDict) mapping layer name strings to tensor metadata with storage references. WARNING: Pickle protocol allows arbitrary Python code execution including os.system(), subprocess, eval(), and __reduce__() exploits."
+    },
+    {
+      "type": "data",
+      "name": "ZIP Entries: archive/data/N",
+      "offset": "variable",
+      "length": "variable",
+      "color": "#DDA0DD",
+      "opacity": 0.55,
+      "description": "Raw tensor buffer files (archive/data/0, archive/data/1, ...) each containing a single tensor's weight data in its native dtype (float32, float16, bfloat16, int8). Referenced by storage offset in the pickle state_dict."
+    },
+    {
+      "type": "metadata",
+      "name": "ZIP Entry: archive/version",
+      "offset": "variable",
+      "length": "variable",
+      "color": "#C2185B",
+      "opacity": 0.5,
+      "description": "Text file containing the PyTorch serialization version number (e.g., '3'). Version 1 = legacy format, version 2 = ZIP with mmap support, version 3 = current default."
+    }
+  ],
+
+  "assertions": [
+    {
+      "name": "ZIPOrPickleMagic",
+      "expression": "UINT8(0) == 0x50 || UINT8(0) == 0x80",
+      "severity": "error",
+      "message": "First byte is neither 'P' (0x50 for ZIP PK header) nor 0x80 (pickle PROTO opcode); this is not a recognizable PyTorch model file."
+    },
+    {
+      "name": "FileSizeMinimum",
+      "expression": "FILE_SIZE >= 64",
+      "severity": "error",
+      "message": "File is too small (< 64 bytes) to contain a valid PyTorch model with tensor data."
+    },
+    {
+      "name": "SecurityWarning",
+      "expression": "true",
+      "severity": "warning",
+      "message": "PyTorch .pt/.pth files use Python pickle which allows ARBITRARY CODE EXECUTION on load. Never load untrusted files with torch.load(). Use safetensors format instead."
+    },
+    {
+      "name": "FileSizeReasonable",
+      "expression": "FILE_SIZE >= 1024",
+      "severity": "info",
+      "message": "File is very small for a PyTorch model; typical models with weights are at least several kilobytes."
+    }
+  ],
+
+  "navigation": {
+    "bookmarks": [
+      { "name": "ZIP/Pickle Magic",        "offset": 0,  "description": "PK\\x03\\x04 (ZIP) or 0x80 (pickle PROTO opcode)" },
+      { "name": "ZIP Version/Protocol",     "offset": 4,  "description": "ZIP version needed or pickle protocol version byte" },
+      { "name": "ZIP Compression Method",   "offset": 8,  "description": "Stored (0x00) or Deflate (0x08) for first entry" }
+    ]
+  },
+
+  "inspector": {
+    "badge": "PT",
+    "primaryField": "magic",
+    "showQualityScore": true,
+    "groups": [
+      {
+        "name": "Container Header",
+        "fields": [ "magic", "zipVersion", "zipFlags", "zipCompression" ]
+      },
+      {
+        "name": "Security",
+        "fields": [ "magic" ]
+      }
+    ]
+  },
+
+  "exportTemplates": [
+    {
+      "name": "PyTorch Header Summary",
+      "format": "text",
+      "template": "PyTorch Model\n  Magic          : 0x{magic:X8}\n  ZIP Version    : {zipVersion}\n  Compression    : {zipCompression} ({zipCompression_mapped})\n  ⚠ SECURITY: Pickle format — do not load untrusted files"
+    },
+    {
+      "name": "PyTorch JSON Report",
+      "format": "json",
+      "template": "{ \"format\": \"PyTorch\", \"magic\": {magic}, \"zipVersion\": {zipVersion}, \"compression\": {zipCompression}, \"securityRisk\": \"high — pickle allows arbitrary code execution\" }"
+    }
+  ],
+
+  "forensic": {
+    "category": "MachineLearningArtifact",
+    "riskLevel": "high",
+    "suspiciousPatterns": [
+      {
+        "name": "Pickle code execution risk",
+        "condition": "true",
+        "severity": "warning",
+        "description": "PyTorch .pt/.pth files use Python pickle which allows arbitrary code execution on load. NEVER load untrusted .pt files. Use safetensors format instead."
+      },
+      {
+        "name": "Malicious pickle payload",
+        "condition": "true",
+        "severity": "warning",
+        "description": "Attackers can embed os.system(), subprocess, or eval() calls in pickle payloads via __reduce__() or __getstate__(). Scan with fickling or picklescan before loading."
+      },
+      {
+        "name": "Obfuscated pickle opcodes",
+        "condition": "true",
+        "severity": "warning",
+        "description": "Malicious payloads may use GLOBAL, INST, or STACK_GLOBAL opcodes to import dangerous modules (os, subprocess, builtins) and execute arbitrary commands."
+      },
+      {
+        "name": "Unexpected ZIP entries",
+        "condition": "true",
+        "severity": "info",
+        "description": "ZIP entries outside the expected archive/data.pkl and archive/data/N pattern may contain additional pickle payloads, scripts, or exfiltration code."
+      }
+    ]
+  },
+
+  "aiHints": {
+    "analysisContext": "PyTorch model files come in two variants: (1) Modern ZIP format (PK magic) containing archive/data.pkl (pickled state_dict) + archive/data/N (raw tensor buffers) + archive/version. (2) Legacy format starting with pickle PROTO opcode 0x80. Both variants use Python pickle which allows arbitrary code execution — this is the primary security concern. The ZIP variant is produced by torch.save() since PyTorch 1.6+.",
+    "suggestedInspections": [
+      "Check first 4 bytes to distinguish ZIP variant (PK\\x03\\x04) from legacy pickle variant (0x80 + protocol byte).",
+      "For ZIP variant: list all ZIP entries and verify expected structure (archive/data.pkl, archive/data/N, archive/version).",
+      "Scan the pickle stream for dangerous opcodes: GLOBAL (0x63), INST (0x69), STACK_GLOBAL (0x93) that import Python modules.",
+      "Check archive/version content to identify the PyTorch serialization format version (1, 2, or 3).",
+      "Estimate model parameter count from total tensor buffer sizes and assumed dtype (float32 = 4 bytes/param, float16 = 2 bytes/param).",
+      "For security auditing: use fickling or picklescan to decompile the pickle bytecode and detect malicious payloads before loading with torch.load()."
+    ]
+  },
+
+  "TechnicalDetails": {
+    "specification": "PyTorch serialization: pytorch.org/docs/stable/notes/serialization.html; Python pickle: docs.python.org/3/library/pickle.html; ZIP format: pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT",
+    "endianness": "little-endian (ZIP headers); pickle uses platform-native byte order for some data types",
+    "serializationFormat": "ZIP container with Python pickle + raw tensor buffers",
+    "securityRisk": "CRITICAL — Python pickle allows arbitrary code execution. Malicious .pt files can execute os.system(), install backdoors, or exfiltrate data when loaded with torch.load(). Always use weights_only=True or migrate to SafeTensors format.",
+    "serializationVersions": {
+      "v1": "Legacy raw pickle stream (pre-PyTorch 1.6)",
+      "v2": "ZIP container with mmap support (PyTorch 1.6+)",
+      "v3": "Current default ZIP format (PyTorch 2.0+)"
+    },
+    "notes": "PyTorch 2.0+ defaults to weights_only=False for backward compatibility but warns about security. The torch.load(weights_only=True) flag restricts unpickling to tensor-safe types only. Full migration to SafeTensors is the recommended security mitigation."
+  },
+
+  "QualityMetrics": {
+    "CompletenessScore": 92,
+    "DocumentationLevel": "comprehensive",
+    "BlocksDefined": 7,
+    "ValidationRules": 4,
+    "LastUpdated": "2026-04-14",
+    "PriorityFormat": true,
+    "AutoRefined": false
+  }
+}

--- a/Sources/Core/WpfHexEditor.Core.Definitions/FormatDefinitions/MachineLearning/SAFETENSORS.whfmt
+++ b/Sources/Core/WpfHexEditor.Core.Definitions/FormatDefinitions/MachineLearning/SAFETENSORS.whfmt
@@ -1,0 +1,231 @@
+{
+  "diffMode": "binary",
+  "formatName": "SafeTensors",
+  "version": "1.0",
+  "extensions": [ ".safetensors" ],
+  "description": "Hugging Face SafeTensors format for secure ML model weight storage; uses an 8-byte LE header size followed by a JSON metadata header and raw tensor data, eliminating arbitrary code execution risks inherent in pickle-based formats.",
+  "category": "MachineLearning",
+  "author": "WPFHexaEditor Team",
+  "preferredEditor": "hex-editor",
+  "MimeTypes": [ "application/octet-stream" ],
+
+  "UseCases": [
+    "Safe ML model weight storage without arbitrary code execution risk (unlike pickle-based .pt files)",
+    "Hugging Face Model Hub distribution for LLMs (LLaMA, Mistral, Stable Diffusion, etc.)",
+    "Fast zero-copy tensor loading with memory-mapped I/O for inference pipelines",
+    "Cross-framework weight sharing between PyTorch, TensorFlow, JAX, and Rust ML frameworks"
+  ],
+
+  "software": [
+    { "name": "Hugging Face transformers",  "role": "producer/consumer" },
+    { "name": "safetensors (Python)",       "role": "producer/consumer" },
+    { "name": "safetensors (Rust crate)",   "role": "producer/consumer" },
+    { "name": "llama.cpp",                  "role": "consumer" },
+    { "name": "Netron",                     "role": "consumer" }
+  ],
+
+  "formatRelationships": {
+    "relatedFormats": [ "PYTORCH", "ONNX", "GGUF", "TFLITE" ],
+    "container": null,
+    "notes": "SafeTensors was created by Hugging Face as a security-first alternative to PyTorch's pickle-based .pt format. The format is intentionally simple: a fixed 8-byte header size, a JSON metadata section, and contiguous raw tensor data. No code execution is possible."
+  },
+
+  "references": {
+    "specifications": [
+      "SafeTensors Format Specification (github.com/huggingface/safetensors)"
+    ],
+    "WebLinks": [
+      "https://huggingface.co/docs/safetensors/",
+      "https://github.com/huggingface/safetensors"
+    ]
+  },
+
+  "detection": {
+    "signatures": [
+      {
+        "value": "7B",
+        "offset": 8,
+        "label": "JSON header start '{' at offset 8 (after 8-byte LE header_size)",
+        "weight": 60,
+        "required": true
+      }
+    ],
+    "matchMode": "weighted",
+    "MinimumScore": 60,
+    "Strength": "Medium",
+    "EntropyHint": {
+      "min": 5.0,
+      "max": 8.0,
+      "note": "Raw tensor data (float32/float16/bfloat16 weights) has high entropy approaching 7.5-8.0. The JSON header section has lower entropy around 4.5-5.5."
+    },
+    "validation": {
+      "minFileSize": 16,
+      "maxSignatureOffset": 8
+    }
+  },
+
+  "variables": {
+    "headerSize":     { "offset": 0, "length": 8, "type": "uint64le" },
+    "jsonStartByte":  { "offset": 8, "length": 1, "type": "uint8" },
+    "jsonSecondByte": { "offset": 9, "length": 1, "type": "uint8" }
+  },
+
+  "blocks": [
+    {
+      "type": "field",
+      "name": "Header Size",
+      "offset": 0,
+      "length": 8,
+      "color": "#FF6B6B",
+      "opacity": 0.9,
+      "description": "8-byte unsigned 64-bit little-endian integer specifying the exact byte length of the JSON metadata header that follows. Typical values range from a few hundred bytes (small models) to several megabytes (LLMs with thousands of tensor entries).",
+      "storeAs": "headerSize",
+      "valueType": "uint64",
+      "endianness": "little"
+    },
+    {
+      "type": "signature",
+      "name": "JSON Header Start",
+      "offset": 8,
+      "length": 1,
+      "color": "#4ECDC4",
+      "opacity": 0.85,
+      "description": "First byte of the JSON metadata header; must be 0x7B ('{') indicating the start of a JSON object mapping tensor names to their dtype, shape, and data_offsets.",
+      "storeAs": "jsonStartByte",
+      "valueType": "uint8"
+    },
+    {
+      "type": "field",
+      "name": "JSON Second Byte",
+      "offset": 9,
+      "length": 1,
+      "color": "#45B7D1",
+      "opacity": 0.75,
+      "description": "Second byte of the JSON header; typically 0x22 ('\"') for the opening quote of the first tensor name key, or 0x0A (newline) if the JSON is pretty-printed, or 0x5F ('_') if the first key is '__metadata__'.",
+      "storeAs": "jsonSecondByte",
+      "valueType": "uint8"
+    },
+    {
+      "type": "metadata",
+      "name": "JSON Metadata Header",
+      "offset": 8,
+      "length": "headerSize",
+      "color": "#96CEB4",
+      "opacity": 0.65,
+      "description": "Complete JSON object mapping tensor names to {dtype, shape, data_offsets:[start,end]} entries. May also contain a '__metadata__' key with format version, framework origin, and conversion metadata. Supported dtypes: BOOL, U8, I8, I16, I32, I64, F16, BF16, F32, F64, F8_E4M3, F8_E5M2."
+    },
+    {
+      "type": "data",
+      "name": "Raw Tensor Data",
+      "offset": "8 + headerSize",
+      "length": "remaining",
+      "color": "#DDA0DD",
+      "opacity": 0.5,
+      "description": "Contiguous raw tensor data region; tensors are concatenated in the order defined by data_offsets in the JSON header. Each tensor's bytes are stored without padding or alignment between them. Data types are stored in their native binary representation (e.g., F32 = IEEE 754 single-precision, F16 = IEEE 754 half-precision, BF16 = bfloat16)."
+    }
+  ],
+
+  "assertions": [
+    {
+      "name": "HeaderSizePositive",
+      "expression": "headerSize > 0 && headerSize < 104857600",
+      "severity": "error",
+      "message": "Header size must be between 1 and 100MB; a zero or excessively large header size indicates file corruption."
+    },
+    {
+      "name": "JsonHeaderStartBrace",
+      "expression": "jsonStartByte == 0x7B",
+      "severity": "error",
+      "message": "Byte at offset 8 is not '{' (0x7B); the JSON metadata header is missing or corrupt."
+    },
+    {
+      "name": "FileSizeConsistent",
+      "expression": "FILE_SIZE > headerSize + 8",
+      "severity": "warning",
+      "message": "File size is not larger than header_size + 8; there may be no tensor data or the header size is incorrect."
+    },
+    {
+      "name": "FileSizeMinimum",
+      "expression": "FILE_SIZE >= 16",
+      "severity": "error",
+      "message": "File is too small (< 16 bytes) to contain a valid SafeTensors header."
+    }
+  ],
+
+  "navigation": {
+    "bookmarks": [
+      { "name": "Header Size",         "offset": 0, "description": "8-byte LE uint64 — length of JSON metadata header" },
+      { "name": "JSON Header Start",   "offset": 8, "description": "Start of JSON metadata (should be '{' = 0x7B)" },
+      { "name": "Tensor Data Region",  "offset": "8 + headerSize", "description": "Raw tensor data begins after JSON header" }
+    ]
+  },
+
+  "inspector": {
+    "badge": "SAFE",
+    "primaryField": "headerSize",
+    "showQualityScore": true,
+    "groups": [
+      {
+        "name": "File Structure",
+        "fields": [ "headerSize", "jsonStartByte", "jsonSecondByte" ]
+      },
+      {
+        "name": "Format Info",
+        "fields": [ "headerSize" ]
+      }
+    ]
+  },
+
+  "exportTemplates": [
+    {
+      "name": "SafeTensors Header Summary",
+      "format": "text",
+      "template": "SafeTensors Model\n  Header Size    : {headerSize} bytes\n  JSON Start     : 0x{jsonStartByte:X2}\n  Tensor Data At : offset {headerSize} + 8"
+    },
+    {
+      "name": "SafeTensors JSON Report",
+      "format": "json",
+      "template": "{ \"format\": \"SafeTensors\", \"headerSize\": {headerSize}, \"jsonStartByte\": {jsonStartByte} }"
+    }
+  ],
+
+  "forensic": {
+    "category": "MachineLearningArtifact",
+    "riskLevel": "low",
+    "suspiciousPatterns": [
+      { "pattern": "OversizedHeader",       "description": "JSON header larger than 50MB may indicate malicious padding, embedded data, or an attempt to cause memory exhaustion during parsing." },
+      { "pattern": "MismatchedDataOffsets",  "description": "Tensor data_offsets that overlap, exceed file size, or leave gaps may indicate corruption or deliberate tampering." },
+      { "pattern": "MemorizedTrainingData",  "description": "Tensor weights may inadvertently encode memorized training data that can be extracted via model inversion attacks." }
+    ]
+  },
+
+  "aiHints": {
+    "analysisContext": "SafeTensors uses a minimal binary layout: 8-byte LE header_size + JSON header + raw tensor bytes. The JSON header is the authoritative index of all tensors; each entry specifies dtype (F32/F16/BF16/etc.), shape (dimension array), and data_offsets [start, end] relative to the tensor data region. The format was designed to be simple enough that parsing cannot trigger code execution.",
+    "suggestedInspections": [
+      "Read the 8-byte header_size to determine the JSON header boundary and tensor data start offset.",
+      "Parse the JSON header to enumerate all tensor names, dtypes, shapes, and data_offsets for integrity validation.",
+      "Verify that all data_offsets are contiguous, non-overlapping, and within the file size bounds.",
+      "Check for a '__metadata__' key in the JSON header containing format version and framework origin info.",
+      "Compare total tensor data size (sum of all tensor byte counts from shape * dtype size) against actual file size minus header.",
+      "Identify the model architecture from tensor naming conventions (e.g., 'model.layers.0.self_attn.q_proj.weight' for transformer models)."
+    ]
+  },
+
+  "TechnicalDetails": {
+    "specification": "SafeTensors format: github.com/huggingface/safetensors/blob/main/safetensors/src/lib.rs",
+    "endianness": "little-endian (header_size is uint64 LE; tensor data uses native dtype byte order)",
+    "supportedDtypes": [ "BOOL", "U8", "I8", "I16", "I32", "I64", "F16", "BF16", "F32", "F64", "F8_E4M3", "F8_E5M2" ],
+    "securityModel": "Pure data format — no code execution, no pickle, no arbitrary object deserialization. Safe to load from untrusted sources.",
+    "notes": "Large models (70B+ parameters) are typically sharded across multiple .safetensors files with a JSON index file (model.safetensors.index.json) mapping tensor names to shard filenames."
+  },
+
+  "QualityMetrics": {
+    "CompletenessScore": 90,
+    "DocumentationLevel": "comprehensive",
+    "BlocksDefined": 5,
+    "ValidationRules": 4,
+    "LastUpdated": "2026-04-14",
+    "PriorityFormat": true,
+    "AutoRefined": false
+  }
+}

--- a/Sources/Core/WpfHexEditor.Core.Definitions/FormatDefinitions/MachineLearning/TFLITE.whfmt
+++ b/Sources/Core/WpfHexEditor.Core.Definitions/FormatDefinitions/MachineLearning/TFLITE.whfmt
@@ -1,0 +1,249 @@
+{
+  "diffMode": "binary",
+  "formatName": "TensorFlow Lite Model",
+  "version": "1.0",
+  "extensions": [ ".tflite" ],
+  "description": "TensorFlow Lite model file using FlatBuffer serialization with 'TFL3' file identifier for optimized on-device machine learning inference on mobile, embedded, and edge TPU platforms.",
+  "category": "MachineLearning",
+  "author": "WPFHexaEditor Team",
+  "preferredEditor": "hex-editor",
+  "MimeTypes": [ "application/x-tflite", "application/octet-stream" ],
+
+  "UseCases": [
+    "Mobile ML inference on Android (ML Kit, TFLite Android API) and iOS (TFLite Swift/ObjC API)",
+    "Edge TPU deployment on Google Coral devices with hardware-accelerated inference",
+    "Microcontroller ML with TensorFlow Lite Micro for sub-milliwatt inference on Cortex-M and RISC-V",
+    "On-device AI for real-time object detection, NLP, speech recognition, and pose estimation"
+  ],
+
+  "software": [
+    { "name": "TensorFlow Lite Interpreter",  "role": "consumer" },
+    { "name": "TFLite Model Maker",           "role": "producer" },
+    { "name": "TensorFlow Converter (tflite_convert)", "role": "producer" },
+    { "name": "Netron",                       "role": "consumer" },
+    { "name": "Android ML Kit",               "role": "consumer" },
+    { "name": "Google Coral Edge TPU Compiler", "role": "consumer" }
+  ],
+
+  "formatRelationships": {
+    "relatedFormats": [ "ONNX", "SAFETENSORS", "SavedModel (TensorFlow)", "TensorRT engine" ],
+    "container": null,
+    "notes": "TFLite files use Google FlatBuffers for zero-copy deserialization, enabling fast model loading without parsing overhead. The 'TFL3' file identifier at offset 4 distinguishes TFLite from other FlatBuffer formats."
+  },
+
+  "references": {
+    "specifications": [
+      "TFLite FlatBuffer Schema (github.com/tensorflow/tensorflow/blob/master/tensorflow/lite/schema/schema.fbs)",
+      "FlatBuffers Specification (google.github.io/flatbuffers/)"
+    ],
+    "WebLinks": [
+      "https://www.tensorflow.org/lite",
+      "https://en.wikipedia.org/wiki/TensorFlow_Lite"
+    ]
+  },
+
+  "detection": {
+    "signatures": [
+      {
+        "value": "54464C33",
+        "offset": 4,
+        "label": "'TFL3' — TensorFlow Lite FlatBuffer file identifier at offset 4",
+        "weight": 100,
+        "required": true
+      }
+    ],
+    "matchMode": "weighted",
+    "MinimumScore": 100,
+    "Strength": "Strong",
+    "EntropyHint": {
+      "min": 4.0,
+      "max": 7.0,
+      "note": "FlatBuffer structural metadata has moderate entropy; quantized model weights (int8) have lower entropy than float32 weights. Fully quantized models typically 4.5-5.5."
+    },
+    "validation": {
+      "minFileSize": 12,
+      "maxSignatureOffset": 4
+    }
+  },
+
+  "variables": {
+    "rootOffset":  { "offset": 0, "length": 4, "type": "uint32le" },
+    "tfliteMagic": { "offset": 4, "length": 4, "type": "ascii" },
+    "firstField":  { "offset": 8, "length": 4, "type": "uint32le" }
+  },
+
+  "blocks": [
+    {
+      "type": "field",
+      "name": "FlatBuffer Root Table Offset",
+      "offset": 0,
+      "length": 4,
+      "color": "#FF6B6B",
+      "opacity": 0.9,
+      "description": "32-bit little-endian offset from the start of the buffer to the root Model table. FlatBuffers use this offset for zero-copy access to the root object without full deserialization.",
+      "storeAs": "rootOffset",
+      "valueType": "uint32",
+      "endianness": "little"
+    },
+    {
+      "type": "signature",
+      "name": "TFLite File Identifier",
+      "offset": 4,
+      "length": 4,
+      "color": "#4ECDC4",
+      "opacity": 0.9,
+      "description": "4-byte ASCII file identifier 'TFL3' (0x54 0x46 0x4C 0x33) embedded by FlatBuffers at offset 4; identifies this as a TensorFlow Lite v3 schema model. Older schema versions may use different identifiers.",
+      "storeAs": "tfliteMagic",
+      "valueType": "ascii"
+    },
+    {
+      "type": "field",
+      "name": "Root Table VTable Offset",
+      "offset": 8,
+      "length": 4,
+      "color": "#45B7D1",
+      "opacity": 0.75,
+      "description": "First 4 bytes of the root Model table area; in FlatBuffer encoding this is typically a signed offset to the vtable that defines which fields are present in the Model table.",
+      "storeAs": "firstField",
+      "valueType": "uint32",
+      "endianness": "little"
+    },
+    {
+      "type": "metadata",
+      "name": "Model Table",
+      "offset": "rootOffset",
+      "length": "variable",
+      "color": "#96CEB4",
+      "opacity": 0.65,
+      "description": "FlatBuffer Model root table containing: version (uint32, schema version 3), operator_codes[] (builtin and custom ops), subgraphs[] (computation graphs), description (string), buffers[] (tensor data), metadata[], and signature_defs[]."
+    },
+    {
+      "type": "metadata",
+      "name": "Subgraphs",
+      "offset": "variable",
+      "length": "variable",
+      "color": "#FFEAA7",
+      "opacity": 0.6,
+      "description": "Vector of SubGraph tables each containing: tensors[] (tensor metadata with shape, type, buffer index), operators[] (op references with input/output tensor indices), inputs[], outputs[], and name."
+    },
+    {
+      "type": "data",
+      "name": "Buffer Data Region",
+      "offset": "variable",
+      "length": "variable",
+      "color": "#DDA0DD",
+      "opacity": 0.5,
+      "description": "Array of data buffers referenced by tensor buffer_index; buffer 0 is always empty (sentinel). Remaining buffers contain raw tensor weights in the model's quantization format (float32, float16, int8, uint8, etc.)."
+    }
+  ],
+
+  "assertions": [
+    {
+      "name": "TFLiteMagicValid",
+      "expression": "tfliteMagic == 'TFL3'",
+      "severity": "error",
+      "message": "File identifier at offset 4 is not 'TFL3'; this is not a valid TensorFlow Lite model or uses an unsupported schema version."
+    },
+    {
+      "name": "RootOffsetValid",
+      "expression": "rootOffset > 0 && rootOffset < FILE_SIZE",
+      "severity": "warning",
+      "message": "FlatBuffer root table offset is zero or exceeds file size; the file may be corrupt."
+    },
+    {
+      "name": "FileSizeMinimum",
+      "expression": "FILE_SIZE >= 12",
+      "severity": "error",
+      "message": "File is too small (< 12 bytes) to contain a valid TFLite FlatBuffer header."
+    },
+    {
+      "name": "FileSizeReasonable",
+      "expression": "FILE_SIZE >= 128",
+      "severity": "info",
+      "message": "File is very small for a TFLite model; valid models with at least one operator and buffer are typically several kilobytes."
+    }
+  ],
+
+  "navigation": {
+    "bookmarks": [
+      { "name": "FlatBuffer Root Offset", "offset": 0, "description": "uint32 LE offset to root Model table" },
+      { "name": "TFL3 Identifier",        "offset": 4, "description": "'TFL3' ASCII file identifier" },
+      { "name": "Root Table Area",         "offset": 8, "description": "Start of FlatBuffer root table / vtable region" }
+    ]
+  },
+
+  "inspector": {
+    "badge": "TFLITE",
+    "primaryField": "tfliteMagic",
+    "showQualityScore": true,
+    "groups": [
+      {
+        "name": "FlatBuffer Header",
+        "fields": [ "rootOffset", "tfliteMagic" ]
+      },
+      {
+        "name": "Model Structure",
+        "fields": [ "firstField" ]
+      }
+    ]
+  },
+
+  "exportTemplates": [
+    {
+      "name": "TFLite Header Summary",
+      "format": "text",
+      "template": "TensorFlow Lite Model\n  File ID        : {tfliteMagic}\n  Root Offset    : {rootOffset}\n  Schema         : TFLite v3 FlatBuffer"
+    },
+    {
+      "name": "TFLite JSON Report",
+      "format": "json",
+      "template": "{ \"format\": \"TFLite\", \"fileIdentifier\": \"{tfliteMagic}\", \"rootOffset\": {rootOffset} }"
+    }
+  ],
+
+  "forensic": {
+    "category": "MachineLearningArtifact",
+    "riskLevel": "low",
+    "suspiciousPatterns": [
+      { "pattern": "CustomOperator",          "description": "Custom operator codes (BuiltinOperator.CUSTOM) reference external operator implementations that could contain arbitrary native code." },
+      { "pattern": "OversizedBuffers",        "description": "Individual tensor buffers significantly larger than expected for the model architecture may indicate embedded non-model data." },
+      { "pattern": "MetadataPayload",         "description": "Model metadata entries can contain arbitrary key-value data including file paths, training configurations, and dataset references." }
+    ]
+  },
+
+  "aiHints": {
+    "analysisContext": "TFLite files use Google FlatBuffers binary format with the 'TFL3' file identifier. FlatBuffers enable zero-copy deserialization: the root table offset at byte 0 points directly to the Model table, and all nested objects use relative offsets. The Model contains operator_codes (enum-indexed built-in ops or custom op strings), subgraphs (tensor metadata + operator graph), and buffers (raw weight data).",
+    "suggestedInspections": [
+      "Verify the 'TFL3' file identifier at offset 4 to confirm TensorFlow Lite schema version 3.",
+      "Follow the root table offset to locate the Model vtable and enumerate available fields (version, operator_codes, subgraphs, buffers).",
+      "Count and identify operator_codes to determine which TFLite built-in operators the model uses (CONV_2D, FULLY_CONNECTED, SOFTMAX, etc.).",
+      "Examine tensor quantization parameters (scale, zero_point) to identify int8/uint8 quantized models vs float32 models.",
+      "Check for custom operator entries that may require user-provided op implementations at inference time.",
+      "Validate buffer data sizes against tensor shape and dtype to detect truncated or corrupt weight data."
+    ]
+  },
+
+  "TechnicalDetails": {
+    "specification": "TFLite schema: github.com/tensorflow/tensorflow/blob/master/tensorflow/lite/schema/schema.fbs; FlatBuffers: google.github.io/flatbuffers/flatbuffers_internals.html",
+    "endianness": "little-endian (FlatBuffers native encoding)",
+    "serializationFormat": "Google FlatBuffers with file_identifier 'TFL3'",
+    "quantizationFormats": {
+      "float32": "Full precision, largest model size",
+      "float16": "Half precision, ~50% size reduction",
+      "int8": "Post-training or quantization-aware training, ~75% size reduction",
+      "uint8": "Legacy quantization format",
+      "int16x8": "16-bit activations with 8-bit weights for improved accuracy"
+    },
+    "notes": "TFLite models are typically converted from TensorFlow SavedModel or Keras models using tf.lite.TFLiteConverter. The FlatBuffer format enables memory-mapped loading on mobile and embedded devices."
+  },
+
+  "QualityMetrics": {
+    "CompletenessScore": 91,
+    "DocumentationLevel": "comprehensive",
+    "BlocksDefined": 6,
+    "ValidationRules": 4,
+    "LastUpdated": "2026-04-14",
+    "PriorityFormat": true,
+    "AutoRefined": false
+  }
+}

--- a/Sources/Core/WpfHexEditor.Core.Definitions/FormatDefinitions/Programming/DIAGSESSION.whfmt
+++ b/Sources/Core/WpfHexEditor.Core.Definitions/FormatDefinitions/Programming/DIAGSESSION.whfmt
@@ -1,0 +1,367 @@
+{
+  "diffMode": "binary",
+  "formatName": "Visual Studio Diagnostic Session",
+  "version": "1.0",
+  "extensions": [ ".diagsession" ],
+  "description": "Visual Studio diagnostic session container — a ZIP archive holding one or more .nettrace EventPipe traces, diagnostics.json session metadata, and optional memory dump files produced by the VS Performance Profiler.",
+  "category": "Programming",
+  "author": "WPFHexaEditor Team",
+  "MimeTypes": [ "application/zip", "application/x-diagsession" ],
+  "UseCases": [
+    "Visual Studio CPU Usage profiling session export",
+    "Memory allocation profiling and heap snapshot storage",
+    ".NET async await performance diagnostics",
+    "Sharing profiling sessions across development teams",
+    "Offline analysis of production application performance"
+  ],
+  "software": [
+    { "name": "Visual Studio Performance Profiler", "role": "producer/consumer" },
+    { "name": "dotnet-trace (via conversion)",      "role": "related" },
+    { "name": "VSDiagnostics.exe",                  "role": "producer" },
+    { "name": "PerfView (via .nettrace export)",     "role": "consumer" }
+  ],
+  "formatRelationships": {
+    "relatedFormats": [ ".nettrace (embedded)", "ZIP (.zip)", "ETL (.etl)", ".dmp (memory dump)" ],
+    "container": "ZIP (PKZIP / Info-ZIP format, DEFLATE or STORE compression)",
+    "notes": "diagsession files are standard ZIP archives. The internal structure includes at least one .nettrace file and a diagnostics.json manifest. Older VS versions may also embed .etl files."
+  },
+
+  "detection": {
+    "signatures": [
+      {
+        "value": "504B0304",
+        "offset": 0,
+        "label": "ZIP local file header magic PK\\x03\\x04",
+        "weight": 50,
+        "required": true
+      },
+      {
+        "value": "504B0506",
+        "offset": "end-22",
+        "label": "ZIP End of Central Directory record",
+        "weight": 20,
+        "required": false
+      }
+    ],
+    "extensionSignatures": [
+      {
+        "extension": ".diagsession",
+        "label": "Visual Studio diagnostic session extension",
+        "weight": 30,
+        "required": false
+      }
+    ],
+    "matchMode": "weighted",
+    "MinimumScore": 50,
+    "Strength": "Medium",
+    "EntropyHint": {
+      "min": 6.0,
+      "max": 7.9,
+      "note": "ZIP DEFLATE-compressed entries have near-maximum entropy. STORE-mode entries (e.g. .nettrace that is already LZ4-compressed) also have high entropy."
+    },
+    "validation": {
+      "expression": "UINT32_BE(0) == 0x504B0304",
+      "description": "ZIP local file header magic PK\\x03\\x04 (0x504B0304 big-endian) at offset 0 identifies this as a ZIP container; the .diagsession extension further narrows it to a Visual Studio diagnostic session."
+    }
+  },
+
+  "variables": {
+    "zipSignature":        { "offset": 0,  "length": 4, "type": "bytes" },
+    "versionNeeded":       { "offset": 4,  "length": 2, "type": "uint16le" },
+    "generalPurposeBits":  { "offset": 6,  "length": 2, "type": "uint16le" },
+    "compressionMethod":   { "offset": 8,  "length": 2, "type": "uint16le" },
+    "lastModTime":         { "offset": 10, "length": 2, "type": "uint16le" },
+    "lastModDate":         { "offset": 12, "length": 2, "type": "uint16le" },
+    "crc32":               { "offset": 14, "length": 4, "type": "uint32le" },
+    "compressedSize":      { "offset": 18, "length": 4, "type": "uint32le" },
+    "uncompressedSize":    { "offset": 22, "length": 4, "type": "uint32le" },
+    "fileNameLength":      { "offset": 26, "length": 2, "type": "uint16le" },
+    "extraFieldLength":    { "offset": 28, "length": 2, "type": "uint16le" },
+    "firstEntryFileName":  { "offset": 30, "length": "fileNameLength", "type": "utf8string" }
+  },
+
+  "blocks": [
+    {
+      "type": "signature",
+      "name": "ZIP Local File Header Signature",
+      "offset": 0,
+      "length": 4,
+      "color": "#1B5E20",
+      "opacity": 0.9,
+      "description": "PKZIP local file header magic bytes 'PK\\x03\\x04' (0x504B0304) marking the start of the first ZIP entry; present at the very beginning of all non-split diagsession files.",
+      "storeAs": "zipSignature",
+      "valueType": "bytes"
+    },
+    {
+      "type": "field",
+      "name": "Version Needed to Extract",
+      "offset": 4,
+      "length": 2,
+      "color": "#2E7D32",
+      "opacity": 0.7,
+      "description": "Minimum ZIP specification version required to extract this entry; 20 (v2.0) for DEFLATE, 10 (v1.0) for STORE, 45 (v4.5) for ZIP64 extensions used in large diagsession files.",
+      "storeAs": "versionNeeded",
+      "valueType": "uint16",
+      "endianness": "little",
+      "valueMap": {
+        "10": "v1.0 — STORE only",
+        "20": "v2.0 — DEFLATE compression",
+        "45": "v4.5 — ZIP64 extensions",
+        "63": "v6.3 — Strong encryption"
+      }
+    },
+    {
+      "type": "field",
+      "name": "General Purpose Bit Flag",
+      "offset": 6,
+      "length": 2,
+      "color": "#388E3C",
+      "opacity": 0.65,
+      "description": "ZIP general purpose bit flags controlling encryption, data descriptor presence, and UTF-8 filename encoding for the first entry in the diagsession archive.",
+      "storeAs": "generalPurposeBits",
+      "valueType": "uint16",
+      "endianness": "little",
+      "bitfields": [
+        { "bit": 0, "name": "Encrypted",         "description": "Entry is encrypted (not standard in diagsession files)" },
+        { "bit": 3, "name": "DataDescriptor",     "description": "Data descriptor with CRC-32 and sizes follows compressed data" },
+        { "bit": 11, "name": "UTF8Filename",      "description": "Filename and comment are UTF-8 encoded (bit 11 = EFS flag)" }
+      ]
+    },
+    {
+      "type": "field",
+      "name": "Compression Method",
+      "offset": 8,
+      "length": 2,
+      "color": "#43A047",
+      "opacity": 0.7,
+      "description": "ZIP compression method applied to the first entry; DEFLATE (8) is most common in diagsession files, but .nettrace entries may use STORE (0) since they contain LZ4-compressed event blocks.",
+      "storeAs": "compressionMethod",
+      "valueType": "uint16",
+      "endianness": "little",
+      "valueMap": {
+        "0": "STORE — no compression (used for pre-compressed .nettrace content)",
+        "8": "DEFLATE — standard ZIP compression",
+        "9": "DEFLATE64 — enhanced deflate",
+        "12": "BZIP2 compression",
+        "14": "LZMA compression"
+      }
+    },
+    {
+      "type": "field",
+      "name": "Last Modified Time (MS-DOS)",
+      "offset": 10,
+      "length": 2,
+      "color": "#66BB6A",
+      "opacity": 0.6,
+      "description": "Last modified time of the first entry in MS-DOS packed time format (bits 15-11 hours, 10-5 minutes, 4-0 two-second intervals); useful for approximate session capture time estimation.",
+      "storeAs": "lastModTime",
+      "valueType": "uint16",
+      "endianness": "little"
+    },
+    {
+      "type": "field",
+      "name": "Last Modified Date (MS-DOS)",
+      "offset": 12,
+      "length": 2,
+      "color": "#81C784",
+      "opacity": 0.6,
+      "description": "Last modified date of the first entry in MS-DOS packed date format (bits 15-9 year offset from 1980, 8-5 month, 4-0 day); combined with time field gives the entry creation timestamp.",
+      "storeAs": "lastModDate",
+      "valueType": "uint16",
+      "endianness": "little"
+    },
+    {
+      "type": "field",
+      "name": "CRC-32",
+      "offset": 14,
+      "length": 4,
+      "color": "#A5D6A7",
+      "opacity": 0.65,
+      "description": "CRC-32 checksum of the uncompressed content of the first ZIP entry; used to verify extraction integrity. Zero when the Data Descriptor bit (bit 3) is set in the general purpose flags.",
+      "storeAs": "crc32",
+      "valueType": "uint32",
+      "endianness": "little"
+    },
+    {
+      "type": "field",
+      "name": "Compressed Size",
+      "offset": 18,
+      "length": 4,
+      "color": "#4CAF50",
+      "opacity": 0.65,
+      "description": "Compressed size in bytes of the first entry's data payload; for .nettrace entries with STORE method this equals the uncompressed size of the NetTrace file.",
+      "storeAs": "compressedSize",
+      "valueType": "uint32",
+      "endianness": "little"
+    },
+    {
+      "type": "field",
+      "name": "Uncompressed Size",
+      "offset": 22,
+      "length": 4,
+      "color": "#388E3C",
+      "opacity": 0.65,
+      "description": "Original uncompressed size in bytes of the first entry's data; gives the actual size of the .nettrace or diagnostics.json content before ZIP compression.",
+      "storeAs": "uncompressedSize",
+      "valueType": "uint32",
+      "endianness": "little"
+    },
+    {
+      "type": "field",
+      "name": "File Name Length",
+      "offset": 26,
+      "length": 2,
+      "color": "#2E7D32",
+      "opacity": 0.7,
+      "description": "Byte length of the file name field immediately following the extra field length; used to locate and read the name of the first ZIP entry within the diagsession archive.",
+      "storeAs": "fileNameLength",
+      "valueType": "uint16",
+      "endianness": "little"
+    },
+    {
+      "type": "field",
+      "name": "First Entry File Name",
+      "offset": 30,
+      "length": "fileNameLength",
+      "color": "#1B5E20",
+      "opacity": 0.8,
+      "description": "UTF-8 or CP437-encoded name of the first file inside the diagsession ZIP archive; typically a GUID-based name or 'session.nettrace' for the primary EventPipe trace file.",
+      "storeAs": "firstEntryFileName",
+      "valueType": "utf8string"
+    },
+    {
+      "type": "metadata",
+      "name": "ZIP Central Directory",
+      "offset": "end-computed",
+      "length": "variable",
+      "color": "#558B2F",
+      "opacity": 0.55,
+      "description": "ZIP Central Directory records listing all entries in the diagsession archive with their names, sizes, offsets, and metadata; located before the End of Central Directory record at the end of the file."
+    },
+    {
+      "type": "metadata",
+      "name": "End of Central Directory",
+      "offset": "end-22",
+      "length": 22,
+      "color": "#33691E",
+      "opacity": 0.6,
+      "description": "PKZIP End of Central Directory record ('PK\\x05\\x06') containing the total entry count, central directory size and offset, and optional ZIP comment; marks the logical end of the diagsession archive."
+    }
+  ],
+
+  "assertions": [
+    {
+      "name": "ValidZipMagic",
+      "expression": "UINT32_BE(0) == 0x504B0304",
+      "severity": "error",
+      "message": "ZIP local file header magic 'PK\\x03\\x04' not found at offset 0; this is not a valid diagsession or ZIP file."
+    },
+    {
+      "name": "CompressionMethodKnown",
+      "expression": "UINT16_LE(8) == 0 || UINT16_LE(8) == 8 || UINT16_LE(8) == 9 || UINT16_LE(8) == 12 || UINT16_LE(8) == 14",
+      "severity": "warning",
+      "message": "Compression method is not a recognized ZIP algorithm; the diagsession archive may use an unsupported compression scheme."
+    },
+    {
+      "name": "CompressedSizeNonZero",
+      "expression": "UINT32_LE(18) > 0 || (UINT16_LE(6) & 0x0008) != 0",
+      "severity": "warning",
+      "message": "Compressed size is zero and DataDescriptor flag is not set; the first ZIP entry appears to be empty."
+    },
+    {
+      "name": "FileNameLengthReasonable",
+      "expression": "UINT16_LE(26) > 0 && UINT16_LE(26) < 260",
+      "severity": "warning",
+      "message": "First entry file name length is 0 or exceeds 260 characters; the diagsession archive may have a corrupt local file header."
+    },
+    {
+      "name": "NotEncrypted",
+      "expression": "(UINT16_LE(6) & 0x0001) == 0",
+      "severity": "info",
+      "message": "The first ZIP entry has the encrypted flag set; diagsession archives are not normally encrypted and this may prevent parsing the embedded .nettrace content."
+    }
+  ],
+
+  "navigation": {
+    "bookmarks": [
+      { "name": "ZIP Local File Header",    "offset": 0,  "description": "First PKZIP local file header — PK\\x03\\x04 magic" },
+      { "name": "Compression Method",       "offset": 8,  "description": "ZIP compression method (0=STORE, 8=DEFLATE)" },
+      { "name": "Compressed/Uncompressed",  "offset": 18, "description": "Compressed (4B) and uncompressed (4B) sizes of first entry" },
+      { "name": "First Entry Name",         "offset": 30, "description": "File name of first ZIP entry (typically .nettrace or diagnostics.json)" }
+    ]
+  },
+
+  "inspector": {
+    "badge": "DIAG",
+    "primaryField": "firstEntryFileName",
+    "showQualityScore": true,
+    "groups": [
+      {
+        "name": "ZIP Container",
+        "fields": [ "zipSignature", "versionNeeded", "compressionMethod" ]
+      },
+      {
+        "name": "First Entry",
+        "fields": [ "compressedSize", "uncompressedSize", "crc32", "firstEntryFileName" ]
+      },
+      {
+        "name": "Entry Flags",
+        "fields": [ "generalPurposeBits", "lastModTime", "lastModDate" ]
+      }
+    ]
+  },
+
+  "exportTemplates": [
+    {
+      "name": "DiagSession Summary",
+      "format": "text",
+      "template": "Visual Studio Diagnostic Session\n  Container      : ZIP archive\n  First Entry    : {firstEntryFileName}\n  Compressed     : {compressedSize} bytes\n  Uncompressed   : {uncompressedSize} bytes\n  Compression    : {compressionMethod} ({compressionMethod_mapped})"
+    },
+    {
+      "name": "DiagSession JSON Report",
+      "format": "json",
+      "template": "{ \"format\": \"DiagSession\", \"container\": \"ZIP\", \"firstEntry\": \"{firstEntryFileName}\", \"compressedSize\": {compressedSize}, \"uncompressedSize\": {uncompressedSize}, \"compressionMethod\": {compressionMethod} }"
+    }
+  ],
+
+  "forensic": {
+    "category": "DiagnosticArtifact",
+    "riskLevel": "medium",
+    "suspiciousPatterns": [
+      { "pattern": "SensitivePathInDiagnostics",  "description": "diagnostics.json inside the archive may contain full file system paths, process names, and environment information from the profiled machine." },
+      { "pattern": "HeapDumpEmbedded",            "description": "Some diagsession variants embed .dmp memory dump files which may contain sensitive in-memory data including credentials and encryption keys." },
+      { "pattern": "EncryptedEntries",            "description": "Encrypted ZIP entries in a diagsession file are unusual and may indicate non-standard tooling or deliberate obfuscation." },
+      { "pattern": "NetTraceWithEventPayloads",   "description": "Embedded .nettrace files may contain EventSource event payloads capturing application-level data passed to tracing APIs." }
+    ]
+  },
+
+  "aiHints": {
+    "analysisContext": "diagsession files are standard ZIP archives produced by Visual Studio's Performance Profiler. The primary payload is one or more .nettrace EventPipe files. The diagnostics.json manifest describes the profiling session parameters, target process, and collection configuration. The ZIP structure can be parsed with any ZIP library before extracting the embedded .nettrace content for analysis.",
+    "suggestedInspections": [
+      "List all ZIP entries to identify the .nettrace files, diagnostics.json manifest, and any embedded .dmp memory dumps.",
+      "Extract and parse diagnostics.json to determine the profiling session type (CPU, memory, async), target process name, and collection duration.",
+      "Locate the primary .nettrace entry and verify its FastSerialization.1 magic after decompression.",
+      "Check ZIP entry timestamps (MS-DOS format) to reconstruct the approximate session capture date and time.",
+      "Look for multiple .nettrace entries in the archive — Visual Studio may split long sessions across multiple trace files.",
+      "Inspect general purpose bit flags for encryption or UTF-8 filename indicators that may affect ZIP parsing."
+    ]
+  },
+
+  "TechnicalDetails": {
+    "specification": "PKWARE ZIP Application Note (APPNOTE.TXT) v6.3.9; Visual Studio diagsession format is undocumented but follows ZIP+JSON+NetTrace conventions observable in VS 2019+",
+    "endianness": "little-endian (ZIP format standard)",
+    "containerFormat": "ZIP (PKZIP APPNOTE.TXT compatible)",
+    "knownInternalFiles": [ "*.nettrace", "diagnostics.json", "metadata.json", "*.dmp" ],
+    "notes": "The diagsession extension distinguishes it from generic ZIP files. Older Visual Studio versions (2017 and earlier) used .diagsession files with different internal layouts, sometimes containing .etl files instead of .nettrace."
+  },
+
+  "QualityMetrics": {
+    "CompletenessScore": 90,
+    "DocumentationLevel": "comprehensive",
+    "BlocksDefined": 13,
+    "ValidationRules": 5,
+    "LastUpdated": "2026-04-14",
+    "PriorityFormat": false,
+    "AutoRefined": false
+  }
+}

--- a/Sources/Core/WpfHexEditor.Core.Definitions/FormatDefinitions/Programming/DOTNET_RESOURCES.whfmt
+++ b/Sources/Core/WpfHexEditor.Core.Definitions/FormatDefinitions/Programming/DOTNET_RESOURCES.whfmt
@@ -1,0 +1,340 @@
+{
+  "diffMode": "binary",
+  "formatName": ".NET Resources File",
+  "version": "1.0",
+  "extensions": [ ".resources" ],
+  "description": "Binary .NET resource file compiled from .resx XML by ResGen or MSBuild; starts with magic 0xBEEFCACE and contains typed key-value resource pairs for System.Resources.ResourceManager.",
+  "category": "Programming",
+  "author": "WPFHexaEditor Team",
+  "MimeTypes": [ "application/octet-stream", "application/x-dotnet-resources" ],
+  "UseCases": [
+    "Localization resource bundles embedded in .NET assemblies",
+    "String, image, icon, and binary data resources for WinForms/WPF apps",
+    "Satellite assembly resource extraction",
+    "Reverse engineering localized .NET application strings",
+    "MSBuild intermediate resource compilation artifact"
+  ],
+  "software": [
+    { "name": "MSBuild / ResGen.exe",            "role": "producer" },
+    { "name": "System.Resources.ResourceManager","role": "consumer" },
+    { "name": "ILSpy / dnSpy",                   "role": "consumer" },
+    { "name": "JustDecompile",                   "role": "consumer" },
+    { "name": "ResXResourceReader",              "role": "related" }
+  ],
+  "formatRelationships": {
+    "relatedFormats": [ ".resx (XML source)", ".resw (Windows Store)", "Win32 .res (binary resource)", "PE resource section (.rsrc)" ],
+    "container": null,
+    "notes": "Compiled .resources files are typically embedded in .NET PE assemblies as a manifest resource and are loaded by ResourceManager at runtime."
+  },
+
+  "detection": {
+    "signatures": [
+      {
+        "value": "CEEFCABE",
+        "offset": 0,
+        "label": "BEEFCACE magic stored little-endian as CE CA EF BE",
+        "weight": 80,
+        "required": true
+      },
+      {
+        "value": "01000000",
+        "offset": 4,
+        "label": "ResourceManagerHeaderVersion = 1",
+        "weight": 10,
+        "required": false
+      },
+      {
+        "value": "02000000",
+        "offset": 4,
+        "label": "ResourceManagerHeaderVersion = 2",
+        "weight": 10,
+        "required": false
+      }
+    ],
+    "matchMode": "weighted",
+    "MinimumScore": 80,
+    "Strength": "Strong",
+    "EntropyHint": {
+      "min": 3.0,
+      "max": 6.5,
+      "note": "String-heavy resource files have moderate entropy; image/binary resource files can push entropy higher."
+    },
+    "validation": {
+      "expression": "UINT32_LE(0) == 0xBEEFCACE",
+      "description": "The 32-bit little-endian value at offset 0 must equal 0xBEEFCACE to confirm this is a .NET binary resources file."
+    }
+  },
+
+  "variables": {
+    "magic":                       { "offset": 0,  "length": 4,  "type": "uint32le" },
+    "resourceManagerHeaderVersion":{ "offset": 4,  "length": 4,  "type": "uint32le" },
+    "numBytesToSkip":              { "offset": 8,  "length": 4,  "type": "uint32le" },
+    "classNameLength":             { "offset": 12, "length": 1,  "type": "uint8",   "note": "7-bit encoded length prefix of ResourceReader class name" },
+    "runtimeVersion2Magic":        { "offset": "variable", "length": 4, "type": "uint32le", "note": "RuntimeResourceSet v2 magic = 0xBEEFCACE again" },
+    "runtimeHeaderVersion":        { "offset": "variable", "length": 4, "type": "uint32le" },
+    "numResources":                { "offset": "variable", "length": 4, "type": "uint32le" }
+  },
+
+  "blocks": [
+    {
+      "type": "signature",
+      "name": "BEEFCACE Magic",
+      "offset": 0,
+      "length": 4,
+      "color": "#BF360C",
+      "opacity": 0.9,
+      "description": "32-bit little-endian magic value 0xBEEFCACE (stored as bytes CE CA EF BE) identifying this as a compiled .NET binary resource file created by System.Resources.ResourceWriter.",
+      "storeAs": "magic",
+      "valueType": "uint32",
+      "endianness": "little"
+    },
+    {
+      "type": "field",
+      "name": "ResourceManagerHeaderVersion",
+      "offset": 4,
+      "length": 4,
+      "color": "#E64A19",
+      "opacity": 0.75,
+      "description": "Version of the ResourceManager header format; version 1 is used by .NET Framework 1.0–4.x; version 2 was defined but never shipped in a public runtime release.",
+      "storeAs": "resourceManagerHeaderVersion",
+      "valueType": "uint32",
+      "endianness": "little",
+      "valueMap": {
+        "1": "ResourceManager header v1 (.NET Framework 1.0+)",
+        "2": "ResourceManager header v2 (defined, not publicly shipped)"
+      }
+    },
+    {
+      "type": "field",
+      "name": "NumBytesToSkip",
+      "offset": 8,
+      "length": 4,
+      "color": "#FF7043",
+      "opacity": 0.7,
+      "description": "Number of bytes to skip past the ResourceManager header to reach the RuntimeResourceSet data; allows readers to skip unknown header extensions introduced by newer producers.",
+      "storeAs": "numBytesToSkip",
+      "valueType": "uint32",
+      "endianness": "little"
+    },
+    {
+      "type": "field",
+      "name": "ResourceReader Class Name (7-bit encoded)",
+      "offset": 12,
+      "length": "variable",
+      "color": "#FF8A65",
+      "opacity": 0.75,
+      "description": "BinaryReader-style 7-bit length-encoded string containing the assembly-qualified name of the IResourceReader implementation, typically 'System.Resources.ResourceReader, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.",
+      "storeAs": "resourceReaderClassName",
+      "valueType": "dotnet7bitstring"
+    },
+    {
+      "type": "field",
+      "name": "IResourceSet Class Name (7-bit encoded)",
+      "offset": "variable",
+      "length": "variable",
+      "color": "#FFAB91",
+      "opacity": 0.7,
+      "description": "BinaryReader-style 7-bit length-encoded string containing the assembly-qualified name of the IResourceSet implementation, typically 'System.Resources.RuntimeResourceSet, mscorlib, ...'.",
+      "storeAs": "resourceSetClassName",
+      "valueType": "dotnet7bitstring"
+    },
+    {
+      "type": "signature",
+      "name": "RuntimeResourceSet Magic (v2 header)",
+      "offset": "12+numBytesToSkip",
+      "length": 4,
+      "color": "#D84315",
+      "opacity": 0.8,
+      "description": "Second occurrence of 0xBEEFCACE magic at the start of the RuntimeResourceSet version 2 header block, confirming the resource data section is intact.",
+      "storeAs": "runtimeVersion2Magic",
+      "valueType": "uint32",
+      "endianness": "little"
+    },
+    {
+      "type": "field",
+      "name": "RuntimeResourceSet HeaderVersion",
+      "offset": "16+numBytesToSkip",
+      "length": 4,
+      "color": "#F4511E",
+      "opacity": 0.65,
+      "description": "Version of the RuntimeResourceSet data format; version 2 introduced in .NET Framework 2.0 adds pre-serialized type names and hash-based resource lookup tables.",
+      "storeAs": "runtimeHeaderVersion",
+      "valueType": "uint32",
+      "endianness": "little",
+      "valueMap": {
+        "1": "RuntimeResourceSet v1 — .NET Framework 1.0/1.1",
+        "2": "RuntimeResourceSet v2 — .NET Framework 2.0+ with type name table"
+      }
+    },
+    {
+      "type": "field",
+      "name": "Number of Resources",
+      "offset": "20+numBytesToSkip",
+      "length": 4,
+      "color": "#FF6E40",
+      "opacity": 0.7,
+      "description": "Total count of resource key-value pairs stored in this file; used to size the hash table and name/offset arrays that follow in the RuntimeResourceSet header.",
+      "storeAs": "numResources",
+      "valueType": "uint32",
+      "endianness": "little"
+    },
+    {
+      "type": "metadata",
+      "name": "Resource Type Name Table",
+      "offset": "variable",
+      "length": "variable",
+      "color": "#BF360C",
+      "opacity": 0.55,
+      "description": "Array of 7-bit encoded type name strings (v2 only) listing the .NET types of each resource value; allows deserialization without loading all resource data."
+    },
+    {
+      "type": "metadata",
+      "name": "Hash Code Array",
+      "offset": "variable",
+      "length": "4*numResources",
+      "color": "#8D6E63",
+      "opacity": 0.5,
+      "description": "Array of numResources 32-bit hash codes of resource key names; used for O(1) resource lookup by ResourceManager without scanning all key strings."
+    },
+    {
+      "type": "metadata",
+      "name": "Name Offset Array",
+      "offset": "variable",
+      "length": "4*numResources",
+      "color": "#A1887F",
+      "opacity": 0.5,
+      "description": "Array of numResources 32-bit offsets into the Name section giving the byte position of each resource key string; parallel to the Hash Code Array."
+    },
+    {
+      "type": "metadata",
+      "name": "Data Section Offset",
+      "offset": "variable",
+      "length": 4,
+      "color": "#795548",
+      "opacity": 0.55,
+      "description": "32-bit offset to the start of the Data section relative to the beginning of the file; the Data section contains the serialized resource values."
+    },
+    {
+      "type": "repeating",
+      "name": "Resource Key-Value Entries",
+      "offset": "variable",
+      "length": "variable",
+      "color": "#6D4C41",
+      "opacity": 0.5,
+      "description": "Variable-length encoded resource entries; each entry has a 7-bit encoded key string length, the UTF-16LE key, a 7-bit type code, and the serialized value payload."
+    }
+  ],
+
+  "assertions": [
+    {
+      "name": "ValidMagic",
+      "expression": "UINT32_LE(0) == 0xBEEFCACE",
+      "severity": "error",
+      "message": "Magic 0xBEEFCACE not found at offset 0; this is not a valid .NET binary resources file."
+    },
+    {
+      "name": "SupportedHeaderVersion",
+      "expression": "UINT32_LE(4) == 1 || UINT32_LE(4) == 2",
+      "severity": "warning",
+      "message": "ResourceManagerHeaderVersion is not 1 or 2; unknown version may indicate a newer or non-standard resource format."
+    },
+    {
+      "name": "NumBytesToSkipReasonable",
+      "expression": "UINT32_LE(8) < 65536",
+      "severity": "warning",
+      "message": "NumBytesToSkip exceeds 64 KB; this is unusually large and may indicate file corruption or a non-standard resource header."
+    },
+    {
+      "name": "RuntimeVersion2MagicCheck",
+      "expression": "UINT32_LE(12 + UINT32_LE(8)) == 0xBEEFCACE",
+      "severity": "error",
+      "message": "RuntimeResourceSet magic at the computed v2 header offset is missing; the resource data section may be corrupt or the NumBytesToSkip value is incorrect."
+    },
+    {
+      "name": "ResourceCountReasonable",
+      "expression": "UINT32_LE(20 + UINT32_LE(8)) < 100000",
+      "severity": "warning",
+      "message": "Resource count exceeds 100,000; this is implausible for a standard .resources file and may indicate a corrupt header or incorrect offset calculation."
+    }
+  ],
+
+  "navigation": {
+    "bookmarks": [
+      { "name": "BEEFCACE Magic",            "offset": 0,  "description": "Primary .NET resources file magic value" },
+      { "name": "ResourceManager Header",    "offset": 4,  "description": "Version and skip-bytes header" },
+      { "name": "ResourceReader Class Name", "offset": 12, "description": "7-bit encoded assembly-qualified ResourceReader type name" }
+    ]
+  },
+
+  "inspector": {
+    "badge": "RES",
+    "primaryField": "numResources",
+    "showQualityScore": true,
+    "groups": [
+      {
+        "name": "File Header",
+        "fields": [ "magic", "resourceManagerHeaderVersion", "numBytesToSkip" ]
+      },
+      {
+        "name": "Reader & Set Types",
+        "fields": [ "resourceReaderClassName", "resourceSetClassName" ]
+      },
+      {
+        "name": "Resource Data",
+        "fields": [ "runtimeVersion2Magic", "runtimeHeaderVersion", "numResources" ]
+      }
+    ]
+  },
+
+  "exportTemplates": [
+    {
+      "name": "Resources Summary",
+      "format": "text",
+      "template": ".NET Binary Resources\n  Header Version  : {resourceManagerHeaderVersion}\n  Runtime Version : {runtimeHeaderVersion}\n  Resource Count  : {numResources}\n  Skip Bytes      : {numBytesToSkip}"
+    },
+    {
+      "name": "Resources JSON Report",
+      "format": "json",
+      "template": "{ \"format\": \"DotNetResources\", \"headerVersion\": {resourceManagerHeaderVersion}, \"runtimeVersion\": {runtimeHeaderVersion}, \"resourceCount\": {numResources} }"
+    }
+  ],
+
+  "forensic": {
+    "category": "ProgrammingArtifact",
+    "riskLevel": "low",
+    "suspiciousPatterns": [
+      { "pattern": "ExecutableInResources",    "description": "Binary resource entries with PE magic (MZ) or script content may indicate payload embedding for dropper malware." },
+      { "pattern": "ObfuscatedClassName",      "description": "ResourceReader class name that does not match known mscorlib types may indicate a custom or malicious deserializer." },
+      { "pattern": "LargeResourceCount",       "description": "Implausibly large resource count or corrupted hash table may indicate anti-analysis tampering of the resource header." }
+    ]
+  },
+
+  "aiHints": {
+    "analysisContext": ".NET binary .resources files pack typed key-value pairs using BinaryWriter encoding. The format uses two nested magic headers and 7-bit integer encoding for string lengths. Version 2 adds a type name table enabling faster typed resource deserialization without loading all values.",
+    "suggestedInspections": [
+      "Verify both BEEFCACE magic values are present — one at offset 0 and one at offset 12+NumBytesToSkip.",
+      "Decode the 7-bit encoded ResourceReader class name to identify the .NET version and public key token.",
+      "Calculate the hash code array and name offset array positions using NumResources to validate the resource index.",
+      "Inspect the Data section for embedded binary blobs (images, icons, audio) that may contain embedded files.",
+      "Check the RuntimeResourceSet version (1 vs 2) to determine if a type name table is present before the hash array."
+    ]
+  },
+
+  "TechnicalDetails": {
+    "specification": "Microsoft .NET ResourceManager binary format — ResourceReader.cs source in dotnet/runtime; ECMA-335 annex on resource embedding; 'Resource File Formats' in .NET documentation",
+    "endianness": "little-endian",
+    "stringEncoding": "7-bit variable-length BinaryWriter encoding for string lengths; UTF-16LE for key strings; UTF-8 for type names",
+    "magicValue": "0xBEEFCACE = 3203399886 decimal",
+    "notes": "The magic appears twice: once in the ResourceManager outer header and once in the RuntimeResourceSet inner header. NumBytesToSkip allows forward compatibility by skipping unknown header extensions."
+  },
+
+  "QualityMetrics": {
+    "CompletenessScore": 90,
+    "DocumentationLevel": "comprehensive",
+    "BlocksDefined": 12,
+    "ValidationRules": 5,
+    "LastUpdated": "2026-04-14",
+    "PriorityFormat": false,
+    "AutoRefined": false
+  }
+}

--- a/Sources/Core/WpfHexEditor.Core.Definitions/FormatDefinitions/Programming/NETTRACE.whfmt
+++ b/Sources/Core/WpfHexEditor.Core.Definitions/FormatDefinitions/Programming/NETTRACE.whfmt
@@ -1,0 +1,291 @@
+{
+  "diffMode": "binary",
+  "formatName": ".NET EventPipe Trace (NetTrace)",
+  "version": "1.0",
+  "extensions": [ ".nettrace" ],
+  "description": "EventPipe diagnostic trace file produced by the .NET runtime; starts with the magic string '!FastSerialization.1' followed by a null byte and a stream of tagged serialization objects including MetadataBlocks, EventBlocks, StackBlocks, and SequencePointBlocks.",
+  "category": "Programming",
+  "author": "WPFHexaEditor Team",
+  "MimeTypes": [ "application/octet-stream", "application/x-nettrace" ],
+  "UseCases": [
+    ".NET runtime CPU sampling and performance profiling",
+    "GC allocation and garbage collection event analysis",
+    "Thread contention and lock analysis in managed code",
+    "EventSource / EventCounter data collection",
+    "PerfView, dotnet-trace, and Visual Studio profiler trace files"
+  ],
+  "software": [
+    { "name": "dotnet-trace",                   "role": "producer" },
+    { "name": "Visual Studio Profiler",         "role": "producer/consumer" },
+    { "name": "PerfView",                       "role": "consumer" },
+    { "name": "SpeedScope (via conversion)",    "role": "consumer" },
+    { "name": "Microsoft.Diagnostics.Tracing.TraceEvent", "role": "consumer" }
+  ],
+  "formatRelationships": {
+    "relatedFormats": [ "ETL (.etl)", ".diagsession (ZIP container)", "Speedscope JSON", "Firefox Profiler JSON" ],
+    "container": null,
+    "notes": "NetTrace files use FastSerialization, a custom .NET binary serialization format. They are also embedded in .diagsession ZIP containers produced by Visual Studio."
+  },
+
+  "detection": {
+    "signatures": [
+      {
+        "value": "2146617374536572",
+        "offset": 0,
+        "label": "!FastSerialization.1 — first 8 bytes of ASCII magic",
+        "weight": 60,
+        "required": true
+      },
+      {
+        "value": "69616C697A6174696F6E2E31",
+        "offset": 8,
+        "label": "Continuation of !FastSerialization.1 — 'ialization.1'",
+        "weight": 20,
+        "required": false
+      },
+      {
+        "value": "00",
+        "offset": 20,
+        "label": "Null terminator after magic string",
+        "weight": 10,
+        "required": false
+      }
+    ],
+    "matchMode": "weighted",
+    "MinimumScore": 60,
+    "Strength": "Strong",
+    "EntropyHint": {
+      "min": 4.0,
+      "max": 7.5,
+      "note": "Event payload blocks are often compressed (LZ4 in v4+); compressed blocks approach entropy 7.5. Metadata blocks with type names have lower entropy."
+    },
+    "validation": {
+      "expression": "STRING_ASCII(0, 20) == '!FastSerialization.1'",
+      "description": "The first 20 bytes must be the ASCII string '!FastSerialization.1' to confirm this is a .NET EventPipe NetTrace file."
+    }
+  },
+
+  "variables": {
+    "magic":            { "offset": 0,  "length": 20, "type": "ascii"  },
+    "nullTerminator":   { "offset": 20, "length": 1,  "type": "uint8"  },
+    "firstObjectType":  { "offset": 21, "length": 1,  "type": "uint8"  },
+    "traceObjectTag":   { "offset": 22, "length": 1,  "type": "uint8"  }
+  },
+
+  "blocks": [
+    {
+      "type": "signature",
+      "name": "FastSerialization Magic",
+      "offset": 0,
+      "length": 20,
+      "color": "#880E4F",
+      "opacity": 0.9,
+      "description": "20-byte ASCII magic string '!FastSerialization.1' (0x21 0x46 0x61 0x73 0x74 0x53 0x65 0x72 0x69 0x61 0x6C 0x69 0x7A 0x61 0x74 0x69 0x6F 0x6E 0x2E 0x31) uniquely identifying this as a .NET EventPipe NetTrace file.",
+      "storeAs": "magic",
+      "valueType": "ascii"
+    },
+    {
+      "type": "field",
+      "name": "Null Terminator",
+      "offset": 20,
+      "length": 1,
+      "color": "#AD1457",
+      "opacity": 0.5,
+      "description": "Single null byte (0x00) terminating the magic string in the FastSerialization stream header; its presence confirms the stream was written correctly by the .NET runtime EventPipe writer.",
+      "storeAs": "nullTerminator",
+      "valueType": "uint8"
+    },
+    {
+      "type": "field",
+      "name": "First Object Type Tag",
+      "offset": 21,
+      "length": 1,
+      "color": "#C2185B",
+      "opacity": 0.75,
+      "description": "FastSerialization object type tag for the first object in the stream; expected to be the BeginPrivateObject tag (0x05) indicating the start of the Trace object with format version and timestamp information.",
+      "storeAs": "firstObjectType",
+      "valueType": "uint8",
+      "valueMap": {
+        "1":  "NullReference — null object sentinel",
+        "2":  "BeginObject — start of a named serialized object",
+        "3":  "EndObject — end of current object scope",
+        "4":  "ForwardReference — reference to a previously defined object",
+        "5":  "BeginPrivateObject — start of an anonymous private object (Trace, MetadataBlock, etc.)",
+        "6":  "EndPrivateObject — end of private object scope",
+        "7":  "ForwardDefinition — forward-declares a reference"
+      }
+    },
+    {
+      "type": "metadata",
+      "name": "Trace Object",
+      "offset": 22,
+      "length": "variable",
+      "color": "#E91E63",
+      "opacity": 0.7,
+      "description": "FastSerialization Trace header object containing: format version (int32), minimum reader version (int32), synchronization clock timestamp (int64), wall clock timestamp (SystemTime), trace file path, OS, architecture, and pointer size."
+    },
+    {
+      "type": "repeating",
+      "name": "MetadataBlock Objects",
+      "offset": "variable",
+      "length": "variable",
+      "color": "#9C27B0",
+      "opacity": 0.65,
+      "description": "Variable-count sequence of MetadataBlock objects each describing an event provider GUID, event ID, event name, and field schema used to decode subsequent EventBlock payloads."
+    },
+    {
+      "type": "repeating",
+      "name": "EventBlock Objects",
+      "offset": "variable",
+      "length": "variable",
+      "color": "#7B1FA2",
+      "opacity": 0.6,
+      "description": "Compressed or uncompressed EventBlock objects each containing a batch of runtime events with timestamps, provider references, thread IDs, activity IDs, and variable-length event payload data."
+    },
+    {
+      "type": "repeating",
+      "name": "StackBlock Objects",
+      "offset": "variable",
+      "length": "variable",
+      "color": "#6A1B9A",
+      "opacity": 0.55,
+      "description": "StackBlock objects (introduced in NetTrace v3) containing arrays of call stack frames referenced by stack ID from EventBlock entries; each frame is a 64-bit instruction pointer."
+    },
+    {
+      "type": "repeating",
+      "name": "SequencePointBlock Objects",
+      "offset": "variable",
+      "length": "variable",
+      "color": "#4A148C",
+      "opacity": 0.55,
+      "description": "SequencePointBlock objects (NetTrace v4+, .NET 6+) providing synchronization checkpoints with absolute timestamps; enable partial trace parsing and crash recovery from incomplete files."
+    },
+    {
+      "type": "field",
+      "name": "Stream Terminator (NullReference)",
+      "offset": "end-1",
+      "length": 1,
+      "color": "#CE93D8",
+      "opacity": 0.5,
+      "description": "Single NullReference tag byte (0x01) at the end of the FastSerialization stream indicating no more objects follow; its absence indicates a truncated or incomplete NetTrace file."
+    }
+  ],
+
+  "assertions": [
+    {
+      "name": "ValidMagicString",
+      "expression": "BYTES(0, 20) == [0x21,0x46,0x61,0x73,0x74,0x53,0x65,0x72,0x69,0x61,0x6C,0x69,0x7A,0x61,0x74,0x69,0x6F,0x6E,0x2E,0x31]",
+      "severity": "error",
+      "message": "The 20-byte magic '!FastSerialization.1' is not present at offset 0; this is not a valid .NET EventPipe NetTrace file."
+    },
+    {
+      "name": "NullTerminatorPresent",
+      "expression": "UINT8(20) == 0x00",
+      "severity": "error",
+      "message": "Null terminator missing at offset 20; the FastSerialization magic string must be null-terminated."
+    },
+    {
+      "name": "FirstObjectIsPrivate",
+      "expression": "UINT8(21) == 0x05",
+      "severity": "warning",
+      "message": "First object type tag at offset 21 is not BeginPrivateObject (0x05); the Trace header object may be missing or the file format version is unrecognized."
+    },
+    {
+      "name": "FileSizeMinimum",
+      "expression": "FILE_SIZE >= 64",
+      "severity": "error",
+      "message": "File is too small (< 64 bytes) to contain a valid NetTrace header; file may be empty or severely truncated."
+    },
+    {
+      "name": "FileSizeReasonable",
+      "expression": "FILE_SIZE >= 200",
+      "severity": "info",
+      "message": "File is very small for a NetTrace; a valid trace with at least one event is typically several kilobytes. The file may be an empty trace or a test artifact."
+    }
+  ],
+
+  "navigation": {
+    "bookmarks": [
+      { "name": "FastSerialization Magic", "offset": 0,  "description": "'!FastSerialization.1' ASCII magic — 20 bytes" },
+      { "name": "Null Terminator",         "offset": 20, "description": "Magic string null terminator (0x00)" },
+      { "name": "First Object Tag",        "offset": 21, "description": "BeginPrivateObject tag (0x05) for Trace header object" },
+      { "name": "Trace Header Object",     "offset": 22, "description": "Trace object: format version, timestamps, OS info" }
+    ]
+  },
+
+  "inspector": {
+    "badge": "TRACE",
+    "primaryField": "magic",
+    "showQualityScore": true,
+    "groups": [
+      {
+        "name": "File Header",
+        "fields": [ "magic", "nullTerminator", "firstObjectType" ]
+      },
+      {
+        "name": "Trace Object",
+        "fields": [ "traceObjectTag" ]
+      }
+    ]
+  },
+
+  "exportTemplates": [
+    {
+      "name": "NetTrace Header Summary",
+      "format": "text",
+      "template": ".NET EventPipe NetTrace\n  Magic          : {magic}\n  First Object   : {firstObjectType} ({firstObjectType_mapped})\n  Format         : FastSerialization v1"
+    },
+    {
+      "name": "NetTrace JSON Report",
+      "format": "json",
+      "template": "{ \"format\": \"NetTrace\", \"magic\": \"{magic}\", \"firstObjectType\": {firstObjectType} }"
+    }
+  ],
+
+  "forensic": {
+    "category": "DiagnosticArtifact",
+    "riskLevel": "medium",
+    "suspiciousPatterns": [
+      { "pattern": "SensitiveStringInTrace",    "description": "EventBlock payloads may contain environment variable values, file paths, and command-line arguments captured during profiling." },
+      { "pattern": "HeapSnapshotData",          "description": "GC heap dump events captured in trace may contain application data including strings and object graphs." },
+      { "pattern": "TruncatedTrace",            "description": "Missing NullReference terminator indicates abnormal process termination; events between last SequencePoint and end of file may be incomplete." },
+      { "pattern": "ExceptionEventChain",       "description": "Sequences of Exception events can reveal internal application error handling paths and sensitive operation context." }
+    ]
+  },
+
+  "aiHints": {
+    "analysisContext": "NetTrace files use .NET FastSerialization, a custom tagged binary protocol. The format streams objects of 5 types: Trace (header), MetadataBlock (event schemas), EventBlock (event batches, optionally LZ4-compressed), StackBlock (call stacks), and SequencePointBlock (checkpoints). Format version in the Trace object determines available block types: v1=.NET Core 2.1, v2=.NET Core 3.0, v3=.NET 5, v4=.NET 6+ (SequencePointBlocks), v5=.NET 8+.",
+    "suggestedInspections": [
+      "Verify the Trace object format version to identify the originating .NET runtime version and available block types.",
+      "Count MetadataBlock entries to enumerate all event providers and event IDs captured in this trace.",
+      "Check for LZ4 compression flag in EventBlock headers — compressed blocks require decompression before event parsing.",
+      "Locate SequencePointBlock entries (v4+ only) to identify safe restart points for partial trace parsing.",
+      "Cross-reference stack frames in StackBlock with module load events to resolve instruction pointers to method names.",
+      "Look for Microsoft-Windows-DotNETRuntime provider events to find GC, JIT, exception, and thread events."
+    ]
+  },
+
+  "TechnicalDetails": {
+    "specification": "Microsoft EventPipe format specification: github.com/microsoft/perfview/blob/main/src/TraceEvent/EventPipe/EventPipeFormat.md; FastSerialization: github.com/microsoft/perfview/blob/main/src/FastSerialization/FastSerialization.md",
+    "endianness": "little-endian",
+    "compressionScheme": "EventBlock payloads optionally LZ4-compressed in NetTrace v4+ (.NET 6+)",
+    "formatVersions": {
+      "v1": ".NET Core 2.1 — initial EventPipe format",
+      "v2": ".NET Core 3.0 — improved metadata",
+      "v3": ".NET 5 — StackBlock support",
+      "v4": ".NET 6 — SequencePointBlock, LZ4 compression",
+      "v5": ".NET 8 — additional block types and metadata improvements"
+    },
+    "notes": "The magic '!FastSerialization.1' is also used by other FastSerialization-based formats (e.g., PerfView .perfview.zip internal files) but the .nettrace extension and Trace object structure distinguish EventPipe files."
+  },
+
+  "QualityMetrics": {
+    "CompletenessScore": 91,
+    "DocumentationLevel": "comprehensive",
+    "BlocksDefined": 9,
+    "ValidationRules": 5,
+    "LastUpdated": "2026-04-14",
+    "PriorityFormat": true,
+    "AutoRefined": false
+  }
+}

--- a/Sources/Core/WpfHexEditor.Core.Definitions/FormatDefinitions/Programming/PORTABLE_PDB.whfmt
+++ b/Sources/Core/WpfHexEditor.Core.Definitions/FormatDefinitions/Programming/PORTABLE_PDB.whfmt
@@ -1,0 +1,354 @@
+{
+  "diffMode": "binary",
+  "formatName": "Portable PDB",
+  "version": "1.0",
+  "extensions": [ ".pdb" ],
+  "description": "Portable Program Database file — ECMA-335 CLI Metadata Root containing debug symbols, sequence points, local variable names, and source document links for .NET assemblies.",
+  "category": "Programming",
+  "author": "WPFHexaEditor Team",
+  "MimeTypes": [ "application/x-portable-pdb", "application/octet-stream" ],
+  "UseCases": [
+    "Debug symbol loading by .NET runtime and debuggers",
+    "Source link resolution during stack trace symbolication",
+    "Code coverage tooling and test result reporting",
+    "Decompiler source mapping (e.g., ILSpy, dnSpy)"
+  ],
+  "software": [
+    { "name": "dotnet build / Roslyn compiler", "role": "producer" },
+    { "name": "Visual Studio Debugger", "role": "consumer" },
+    { "name": "dnSpy / ILSpy", "role": "consumer" },
+    { "name": "dotnet-symbol", "role": "consumer" }
+  ],
+  "formatRelationships": {
+    "relatedFormats": [ "PE/COFF (.dll, .exe)", "Windows PDB (.pdb, legacy)", "Source Link JSON" ],
+    "container": null,
+    "embeddedIn": "Portable PDB can be embedded inside a PE image as a debug directory entry of type 17 (EmbeddedPortablePdb)."
+  },
+
+  "detection": {
+    "signatures": [
+      {
+        "value": "42534A42",
+        "offset": 0,
+        "label": "CLI Metadata Root magic BSJB",
+        "weight": 60,
+        "required": true
+      },
+      {
+        "value": "0100",
+        "offset": 4,
+        "label": "MajorVersion = 1",
+        "weight": 15,
+        "required": false
+      },
+      {
+        "value": "0100",
+        "offset": 6,
+        "label": "MinorVersion = 1",
+        "weight": 10,
+        "required": false
+      },
+      {
+        "value": "00000000",
+        "offset": 8,
+        "label": "Reserved field must be zero",
+        "weight": 5,
+        "required": false
+      }
+    ],
+    "matchMode": "weighted",
+    "MinimumScore": 60,
+    "Strength": "Strong",
+    "EntropyHint": {
+      "min": 3.5,
+      "max": 7.8,
+      "note": "Metadata strings and GUID heaps give moderate entropy; compressed blob heaps can be high."
+    },
+    "validation": {
+      "expression": "UINT32(0) == 0x424A5342",
+      "description": "BSJB signature validates this is a CLI metadata root — shared by PE metadata and standalone Portable PDB files."
+    }
+  },
+
+  "variables": {
+    "signature":       { "offset": 0,  "length": 4,  "type": "bytes" },
+    "majorVersion":    { "offset": 4,  "length": 2,  "type": "uint16le" },
+    "minorVersion":    { "offset": 6,  "length": 2,  "type": "uint16le" },
+    "reserved":        { "offset": 8,  "length": 4,  "type": "uint32le" },
+    "versionLength":   { "offset": 12, "length": 4,  "type": "uint32le" },
+    "versionString":   { "offset": 16, "length": "versionLength", "type": "utf8string" },
+    "flags":           { "offset": "16+versionLength", "length": 2, "type": "uint16le" },
+    "streamCount":     { "offset": "18+versionLength", "length": 2, "type": "uint16le" }
+  },
+
+  "blocks": [
+    {
+      "type": "signature",
+      "name": "CLI Metadata Root Signature",
+      "offset": 0,
+      "length": 4,
+      "color": "#FF5722",
+      "opacity": 0.85,
+      "description": "Four-byte magic 'BSJB' (0x42534A42) identifying this as an ECMA-335 CLI Metadata Root, present in both PE images and standalone Portable PDB files.",
+      "storeAs": "signature",
+      "valueType": "bytes"
+    },
+    {
+      "type": "field",
+      "name": "MajorVersion",
+      "offset": 4,
+      "length": 2,
+      "color": "#2196F3",
+      "opacity": 0.7,
+      "description": "CLI metadata root major version number; always 1 for all known CLI implementations including .NET Framework and .NET Core.",
+      "storeAs": "majorVersion",
+      "valueType": "uint16",
+      "endianness": "little"
+    },
+    {
+      "type": "field",
+      "name": "MinorVersion",
+      "offset": 6,
+      "length": 2,
+      "color": "#2196F3",
+      "opacity": 0.6,
+      "description": "CLI metadata root minor version number; always 1 for all known CLI implementations.",
+      "storeAs": "minorVersion",
+      "valueType": "uint16",
+      "endianness": "little"
+    },
+    {
+      "type": "field",
+      "name": "Reserved",
+      "offset": 8,
+      "length": 4,
+      "color": "#9E9E9E",
+      "opacity": 0.4,
+      "description": "Reserved field, must be zero per ECMA-335 specification §II.24.2.1; non-zero value indicates file corruption or non-standard producer.",
+      "storeAs": "reserved",
+      "valueType": "uint32",
+      "endianness": "little"
+    },
+    {
+      "type": "field",
+      "name": "VersionLength",
+      "offset": 12,
+      "length": 4,
+      "color": "#4CAF50",
+      "opacity": 0.7,
+      "description": "Length in bytes of the version string that follows, padded to the next 4-byte boundary; typical values are 12 (v4.0.30319) or 12 (PDB v1.0).",
+      "storeAs": "versionLength",
+      "valueType": "uint32",
+      "endianness": "little"
+    },
+    {
+      "type": "field",
+      "name": "VersionString",
+      "offset": 16,
+      "length": "versionLength",
+      "color": "#8BC34A",
+      "opacity": 0.8,
+      "description": "Null-terminated UTF-8 version string padded to a 4-byte boundary, e.g. 'v4.0.30319' for .NET Framework or 'PDB v1.0' for Portable PDB documents.",
+      "storeAs": "versionString",
+      "valueType": "utf8string"
+    },
+    {
+      "type": "field",
+      "name": "Flags",
+      "offset": "16+versionLength",
+      "length": 2,
+      "color": "#FF9800",
+      "opacity": 0.6,
+      "description": "Metadata root flags; currently reserved and must be zero per ECMA-335 §II.24.2.1.",
+      "storeAs": "flags",
+      "valueType": "uint16",
+      "endianness": "little"
+    },
+    {
+      "type": "field",
+      "name": "StreamCount",
+      "offset": "18+versionLength",
+      "length": 2,
+      "color": "#9C27B0",
+      "opacity": 0.7,
+      "description": "Number of metadata stream headers that follow immediately after this field; Portable PDB files typically have 5 streams: #Pdb, #~, #Strings, #GUID, #Blob.",
+      "storeAs": "streamCount",
+      "valueType": "uint16",
+      "endianness": "little"
+    },
+    {
+      "type": "metadata",
+      "name": "StreamHeaders",
+      "offset": "20+versionLength",
+      "length": "variable",
+      "color": "#673AB7",
+      "opacity": 0.6,
+      "description": "Array of StreamCount stream header entries, each containing a 4-byte offset, 4-byte size, and null-padded name aligned to a 4-byte boundary."
+    },
+    {
+      "type": "metadata",
+      "name": "#Pdb Stream (Portable PDB specific)",
+      "offset": "computed",
+      "length": "variable",
+      "color": "#E91E63",
+      "opacity": 0.75,
+      "description": "Portable PDB-specific stream containing the PDB ID GUID (20 bytes), entry point token, referenced type system tables bitmask, and type-forwarding data."
+    },
+    {
+      "type": "metadata",
+      "name": "#~ Compressed Metadata Tables",
+      "offset": "computed",
+      "length": "variable",
+      "color": "#00BCD4",
+      "opacity": 0.7,
+      "description": "Compressed metadata table stream (ECMA-335 §II.24.2.6) containing rows for Document, MethodDebugInformation, LocalScope, LocalVariable, and StateMachineMethod tables."
+    },
+    {
+      "type": "metadata",
+      "name": "#Strings Heap",
+      "offset": "computed",
+      "length": "variable",
+      "color": "#FF5722",
+      "opacity": 0.55,
+      "description": "String heap referenced by metadata table rows; contains UTF-8 null-terminated strings such as local variable names, document file paths, and language GUIDs."
+    },
+    {
+      "type": "metadata",
+      "name": "#GUID Heap",
+      "offset": "computed",
+      "length": "variable",
+      "color": "#795548",
+      "opacity": 0.55,
+      "description": "GUID heap storing 16-byte GUIDs for language identifiers, hash algorithms (SHA-1, SHA-256), document checksums, and the PDB ID used to match PDB to PE."
+    },
+    {
+      "type": "metadata",
+      "name": "#Blob Heap",
+      "offset": "computed",
+      "length": "variable",
+      "color": "#607D8B",
+      "opacity": 0.55,
+      "description": "Blob heap storing variable-length binary data including source file checksums, sequence point encoded data, import scope data, and custom debug information payloads."
+    }
+  ],
+
+  "assertions": [
+    {
+      "name": "ValidMagic",
+      "expression": "UINT32(0) == 0x424A5342",
+      "severity": "error",
+      "message": "CLI Metadata Root magic 'BSJB' not found at offset 0; file is not a valid Portable PDB or CLI metadata root."
+    },
+    {
+      "name": "MajorVersionIsOne",
+      "expression": "UINT16_LE(4) == 1",
+      "severity": "warning",
+      "message": "MajorVersion at offset 4 is not 1; all known CLI implementations use MajorVersion=1 per ECMA-335 §II.24.2.1."
+    },
+    {
+      "name": "MinorVersionIsOne",
+      "expression": "UINT16_LE(6) == 1",
+      "severity": "warning",
+      "message": "MinorVersion at offset 6 is not 1; expected value is 1 per ECMA-335 §II.24.2.1."
+    },
+    {
+      "name": "ReservedIsZero",
+      "expression": "UINT32_LE(8) == 0",
+      "severity": "warning",
+      "message": "Reserved field at offset 8 is non-zero; this may indicate file corruption or a non-conforming producer."
+    },
+    {
+      "name": "VersionLengthAligned",
+      "expression": "(UINT32_LE(12) % 4) == 0",
+      "severity": "warning",
+      "message": "VersionLength is not a multiple of 4; the version string must be padded to a 4-byte boundary per ECMA-335."
+    },
+    {
+      "name": "FlagsAreZero",
+      "expression": "UINT16_LE(16 + UINT32_LE(12)) == 0",
+      "severity": "info",
+      "message": "Flags field is non-zero; currently reserved and should be zero per ECMA-335 §II.24.2.1."
+    }
+  ],
+
+  "navigation": {
+    "bookmarks": [
+      { "name": "Metadata Root Header", "offset": 0,    "description": "ECMA-335 CLI Metadata Root — BSJB signature and version info" },
+      { "name": "VersionString",         "offset": 16,   "description": "Null-terminated version string, e.g. 'PDB v1.0' or 'v4.0.30319'" },
+      { "name": "StreamHeaders Start",   "offset": "20+versionLength", "description": "Array of stream header entries (offset/size/name)" }
+    ]
+  },
+
+  "inspector": {
+    "badge": "PDB",
+    "primaryField": "versionString",
+    "showQualityScore": true,
+    "groups": [
+      {
+        "name": "Identification",
+        "fields": [ "signature", "majorVersion", "minorVersion" ]
+      },
+      {
+        "name": "Version",
+        "fields": [ "versionLength", "versionString" ]
+      },
+      {
+        "name": "Stream Directory",
+        "fields": [ "flags", "streamCount" ]
+      }
+    ]
+  },
+
+  "exportTemplates": [
+    {
+      "name": "PDB Header Summary",
+      "format": "text",
+      "template": "Portable PDB\n  Version : {versionString}\n  Streams : {streamCount}\n  Format  : ECMA-335 CLI Metadata Root"
+    },
+    {
+      "name": "PDB JSON Report",
+      "format": "json",
+      "template": "{ \"format\": \"PortablePDB\", \"version\": \"{versionString}\", \"streamCount\": {streamCount}, \"majorVersion\": {majorVersion}, \"minorVersion\": {minorVersion} }"
+    }
+  ],
+
+  "forensic": {
+    "category": "ProgrammingArtifact",
+    "riskLevel": "low",
+    "suspiciousPatterns": [
+      { "pattern": "ReservedNonZero",       "description": "Reserved field at offset 8 is non-zero; possible file tampering or non-standard tool." },
+      { "pattern": "UnexpectedVersionString","description": "Version string does not match known .NET runtime versions; may indicate an obfuscation tool or custom CLI producer." },
+      { "pattern": "ZeroStreamCount",        "description": "StreamCount is zero; a valid Portable PDB must have at least the #Pdb and #~ streams." }
+    ]
+  },
+
+  "aiHints": {
+    "analysisContext": "Portable PDB files use the ECMA-335 CLI Metadata Root structure and contain .NET debug symbols including sequence points, local variable scopes, source document paths, and source link information for remote source retrieval.",
+    "suggestedInspections": [
+      "Verify the PDB ID GUID in the #Pdb stream matches the CodeView debug entry in the corresponding PE file.",
+      "Check the MethodDebugInformation table in the #~ stream for sequence point data encoding source line mappings.",
+      "Inspect #Blob heap entries for source file checksums (SHA-1 or SHA-256) used to validate source integrity.",
+      "Look for embedded source in the CustomDebugInformation table (PortableCustomDebugInfoKinds.EmbeddedSource).",
+      "Cross-reference VersionString 'PDB v1.0' vs 'v4.0.30319' to distinguish standalone Portable PDB from embedded CLI metadata."
+    ]
+  },
+
+  "TechnicalDetails": {
+    "specification": "ECMA-335 6th Edition §II.24.2.1 — Metadata Root; Microsoft Portable PDB specification (github.com/dotnet/runtime/blob/main/docs/design/specs/PortablePdb-Metadata.md)",
+    "endianness": "little-endian",
+    "alignment": "4-byte boundary for version string and stream names",
+    "compressionScheme": "#~ stream uses compressed row counts per ECMA-335 §II.24.2.6",
+    "hashAlgorithms": [ "SHA-1 (legacy)", "SHA-256 (recommended)" ],
+    "notes": "The BSJB magic is shared with PE-embedded CLI metadata; extension .pdb and the absence of a PE DOS header distinguish standalone Portable PDB files."
+  },
+
+  "QualityMetrics": {
+    "CompletenessScore": 92,
+    "DocumentationLevel": "comprehensive",
+    "BlocksDefined": 14,
+    "ValidationRules": 6,
+    "LastUpdated": "2026-04-14",
+    "PriorityFormat": true,
+    "AutoRefined": false
+  }
+}

--- a/Sources/Core/WpfHexEditor.Core.Definitions/FormatDefinitions/Programming/WAT.whfmt
+++ b/Sources/Core/WpfHexEditor.Core.Definitions/FormatDefinitions/Programming/WAT.whfmt
@@ -1,0 +1,193 @@
+{
+  "diffMode": "text",
+  "formatName": "WebAssembly Text Format",
+  "version": "1.0",
+  "extensions": [".wat", ".wast"],
+  "description": "WAT (WebAssembly Text Format) is the human-readable S-expression representation of WebAssembly modules. Defined in the WebAssembly Core Specification (W3C), WAT files are the textual complement to the binary .wasm format. A WAT module begins with `(module` and contains type definitions, imports, function definitions, exports, memory and table declarations, and global variables. Instructions use a stack-based notation: `i32.add`, `f64.mul`, `local.get`, `call`, `br_if`, etc. WAT is compiled to binary .wasm via tools like `wat2wasm` (WABT toolkit) or `wasm-pack`. WAST (.wast) is an extended format used for WebAssembly test scripts — it adds `assert_return`, `assert_trap`, `assert_invalid`, and `invoke` directives around module definitions. Both formats are pure UTF-8 text with no binary structure.",
+  "category": "Programming",
+  "author": "WPFHexaEditor Team",
+  "preferredEditor": "code-editor",
+  "references": {
+    "specifications": [
+      "WebAssembly Core Specification — W3C Text Format §6",
+      "WebAssembly Test Script format (WAST) — WABT documentation"
+    ],
+    "WebLinks": [
+      "https://webassembly.github.io/spec/core/text/index.html",
+      "https://github.com/WebAssembly/wabt",
+      "https://developer.mozilla.org/en-US/docs/WebAssembly/Understanding_the_text_format"
+    ]
+  },
+  "detection": {
+    "signatures": [
+      { "value": "286D6F64756C65", "offset": 0, "label": "'(module' — WebAssembly text module declaration", "weight": 0.9 },
+      { "value": "3B3B", "offset": 0, "label": "';; ' — WAT line comment (may precede module declaration)", "weight": 0.3 },
+      { "value": "286D6F64756C65", "offset": 3, "label": "'(module' at offset 3 (after BOM or whitespace)", "weight": 0.7 }
+    ],
+    "matchMode": "any",
+    "MinimumScore": 0.3,
+    "required": false,
+    "Strength": "Medium",
+    "EntropyHint": { "min": 3.5, "max": 5.5 },
+    "validation": {
+      "minFileSize": 8,
+      "maxSignatureOffset": 64,
+      "note": "WAT files are UTF-8 text. The module body begins with '(module' possibly preceded by line comments (;;) or block comments ((; ... ;)). Detection by extension .wat/.wast and presence of '(module'."
+    }
+  },
+  "variables": {
+    "watFirstByte": 0,
+    "watModuleMarker": ""
+  },
+  "blocks": [
+    {
+      "type": "field",
+      "name": "First Character",
+      "offset": 0,
+      "length": 1,
+      "color": "#4ECDC4",
+      "opacity": 0.35,
+      "description": "First byte of the WAT file. Expected: 0x28 '(' for immediate module declaration, or 0x3B ';' for a leading line comment (;; comment\\n), or 0x28 '(' for a block comment (; ... ;). WAT files are pure UTF-8 text S-expressions. No BOM expected (plain ASCII-compatible UTF-8).",
+      "storeAs": "watFirstByte",
+      "valueType": "uint8",
+      "valueMap": {
+        "40": "0x28 '(' — S-expression open paren (module declaration or comment)",
+        "59": "0x3B ';' — Line comment start (;; ...)",
+        "32": "0x20 ' ' — Leading whitespace before module",
+        "10": "0x0A LF — Empty leading line"
+      }
+    },
+    {
+      "type": "field",
+      "name": "Module Keyword Start",
+      "offset": 1,
+      "length": 6,
+      "color": "#95E1D3",
+      "opacity": 0.3,
+      "description": "Bytes 1-6: expected to be 'module' ASCII (6D 6F 64 75 6C 65) if offset 0 was '('. Together with the opening paren at offset 0, forms the '(module' declaration that wraps the entire WebAssembly module definition in WAT format.",
+      "storeAs": "watModuleMarker",
+      "valueType": "ascii"
+    },
+    {
+      "type": "metadata",
+      "name": "WAT Module Declaration",
+      "variable": "watFirstByte",
+      "description": "Start of WAT S-expression — '(module' wraps entire WebAssembly module"
+    },
+    {
+      "type": "metadata",
+      "name": "Module Keyword",
+      "variable": "watModuleMarker",
+      "description": "'module' keyword following opening paren — confirms WebAssembly Text Format"
+    }
+  ],
+  "assertions": [
+    {
+      "name": "Starts with paren or comment",
+      "expression": "watFirstByte == 40 || watFirstByte == 59 || watFirstByte == 32 || watFirstByte == 10 || watFirstByte == 13",
+      "severity": "warning",
+      "message": "WAT files should start with '(' (module declaration), ';;' (line comment), or whitespace. Unexpected first byte may indicate encoding issue or non-WAT content."
+    },
+    {
+      "name": "Module keyword present",
+      "expression": "watFirstByte == 40",
+      "severity": "info",
+      "message": "File starts with '(' — verify 'module' keyword follows to confirm WAT module format."
+    },
+    {
+      "name": "Text encoding",
+      "expression": "watFirstByte < 128",
+      "severity": "warning",
+      "message": "First byte > 127 — WAT files must be UTF-8 encoded. High byte may indicate wrong encoding or binary content."
+    }
+  ],
+  "navigation": {
+    "bookmarks": [
+      { "name": "Module Declaration", "offset": 0, "icon": "\uE8A5", "color": "#4ECDC4" }
+    ]
+  },
+  "inspector": {
+    "badge": "watFirstByte",
+    "primaryField": "watModuleMarker",
+    "showQualityScore": true,
+    "groups": [
+      {
+        "title": "WAT Module Header",
+        "icon": "\uE8A5",
+        "fields": ["watFirstByte", "watModuleMarker"]
+      }
+    ]
+  },
+  "exportTemplates": [
+    {
+      "name": "WAT Header (JSON)",
+      "format": "json",
+      "fields": ["watFirstByte", "watModuleMarker"]
+    },
+    {
+      "name": "WAT Module Info (Text)",
+      "format": "text",
+      "fields": ["watModuleMarker"]
+    }
+  ],
+  "forensic": {
+    "category": "programming",
+    "riskLevel": "low",
+    "suspiciousPatterns": [
+      {
+        "name": "Obfuscated WAT",
+        "condition": "true",
+        "severity": "info",
+        "description": "WAT files compiled from obfuscated or minified sources may lack readable function names and use only indexed references ($0, $1) making reverse engineering harder. Decompiled WASM to WAT via wasm2wat may reveal malicious code patterns."
+      }
+    ]
+  },
+  "aiHints": {
+    "analysisContext": "WAT (WebAssembly Text Format): pure UTF-8 S-expression text. Starts with '(module'. Key constructs: (type (func ...)), (import \"env\" \"func\" (func ...)), (func $name (param i32) (result i64) ...), (export \"main\" (func $main)), (memory 1), (table funcref). Instructions: i32.const, i32.add, local.get, local.set, call, br_if, if/else/end, loop, block. WAST adds: (assert_return (invoke \"func\") (i32.const 42)) for testing. Compile WAT to WASM: wat2wasm file.wat -o file.wasm. Disassemble WASM to WAT: wasm2wat file.wasm.",
+    "suggestedInspections": [
+      "Find '(import' declarations to see external function/memory dependencies (imports from 'env' or 'wasi_snapshot_preview1')",
+      "Count '(func' declarations to understand module complexity",
+      "Look for '(export' to identify the public API surface of the module",
+      "Check '(memory' and '(data' segments for embedded binary data or strings",
+      "WAST files: look for 'assert_trap' to find known failure cases in test suites"
+    ]
+  },
+  "software": [
+    "wabt (WebAssembly Binary Toolkit — wat2wasm, wasm2wat, wasm-validate, wasm-objdump)",
+    "wasm-pack (Rust to WASM toolchain — compiles Rust to .wat/.wasm)",
+    "Emscripten (C/C++ to WASM — emcc generates .wasm and optional .wat)",
+    "wat-editor (VS Code extension with WAT syntax highlighting)",
+    "Chrome DevTools (WASM Sources panel shows decompiled WAT)"
+  ],
+  "formatRelationships": {
+    "category": "Programming",
+    "extensions": [".wat", ".wast"],
+    "relatedFormats": ["WASM"],
+    "note": "WAT is the text representation of WASM binary. One-to-one mapping: every .wasm can be disassembled to .wat via wasm2wat, and every .wat can be assembled to .wasm via wat2wasm. WAST (.wast) is a superset used for test scripts — not directly compiled to .wasm. WAT uses S-expression syntax like Lisp/Scheme."
+  },
+  "MimeTypes": ["text/plain", "text/wat"],
+  "UseCases": [
+    "Reading and writing human-readable WebAssembly modules",
+    "Debugging and auditing WASM binaries by disassembling to WAT",
+    "Writing WebAssembly test suites in WAST format",
+    "Learning WebAssembly instruction set and stack machine model",
+    "Reverse engineering compiled WASM to understand logic"
+  ],
+  "QualityMetrics": {
+    "CompletenessScore": 78,
+    "DocumentationLevel": "detailed",
+    "BlocksDefined": 4,
+    "ValidationRules": 3,
+    "LastUpdated": "2026-04-14",
+    "PriorityFormat": false,
+    "AutoRefined": false
+  },
+  "TechnicalDetails": {
+    "Format": "UTF-8 text S-expression (WebAssembly Text Format, W3C spec)",
+    "Encoding": "UTF-8 (no BOM required)",
+    "Syntax": "S-expressions: (keyword args...) — similar to Lisp/Scheme",
+    "Module": "(module (type ...) (import ...) (func ...) (export ...) (memory ...) (data ...))",
+    "WAST": "Superset of WAT — adds assert_return, assert_trap, invoke for test scripts",
+    "Tooling": "wabt toolkit: wat2wasm (assemble), wasm2wat (disassemble), wasm-validate"
+  }
+}

--- a/Sources/Core/WpfHexEditor.Core.Definitions/FormatDefinitions/Subtitles/ASS.whfmt
+++ b/Sources/Core/WpfHexEditor.Core.Definitions/FormatDefinitions/Subtitles/ASS.whfmt
@@ -1,0 +1,225 @@
+{
+  "diffMode": "text",
+  "formatName": "Advanced SubStation Alpha",
+  "version": "1.0",
+  "extensions": [ ".ass", ".ssa" ],
+  "description": "Advanced SubStation Alpha (ASS/SSA) is a feature-rich INI-style subtitle format dominant in anime fansubbing; it supports per-character styling, animation, karaoke effects, clipping, motion, and typesetting via override tags in [Events] dialogue lines, with styles defined in [V4+ Styles] and metadata in [Script Info] sections.",
+  "category": "Subtitles",
+  "author": "WPFHexaEditor Team",
+  "preferredEditor": "text-editor",
+  "MimeTypes": [ "text/x-ssa" ],
+  "UseCases": [
+    "Anime fansubbing with complex typesetting and karaoke effects",
+    "Styled subtitle authoring with per-character colors, fonts, and positioning",
+    "Motion graphics and animated text overlays in video",
+    "Multi-style subtitle tracks in MKV containers"
+  ],
+  "software": [
+    { "name": "Aegisub",           "role": "producer/consumer (primary ASS editor)" },
+    { "name": "libass",            "role": "consumer (subtitle renderer)" },
+    { "name": "xy-VSFilter",       "role": "consumer (DirectShow subtitle filter)" },
+    { "name": "mpv",               "role": "consumer (uses libass)" },
+    { "name": "VLC",               "role": "consumer" },
+    { "name": "FFmpeg",            "role": "producer/consumer" },
+    { "name": "MPC-HC",            "role": "consumer" }
+  ],
+  "references": {
+    "specifications": [ "ASS (Advanced SubStation Alpha) format specification", "SSA v4.00 format specification" ],
+    "WebLinks": [ "https://en.wikipedia.org/wiki/SubStation_Alpha", "http://www.tcax.org/docs/ass-specs.htm" ]
+  },
+  "formatRelationships": {
+    "relatedFormats": [ "SSA (SubStation Alpha v4.00)", "SRT (SubRip)", "VTT (WebVTT)" ],
+    "container": null,
+    "notes": "ASS (v4.00+) is the successor to SSA (v4.00). The key differences: [V4+ Styles] vs [V4 Styles], additional override tags, ScaledBorderAndShadow, and extended alignment numbering. ASS is commonly muxed into MKV containers."
+  },
+
+  "detection": {
+    "signatures": [
+      {
+        "value": "5B53637269707420496E666F5D",
+        "offset": 0,
+        "label": "'[Script Info]' — ASS/SSA mandatory first section header (13 bytes)",
+        "weight": 60,
+        "required": true
+      },
+      {
+        "value": "EFBBBF5B53637269707420496E666F5D",
+        "offset": 0,
+        "label": "UTF-8 BOM (EF BB BF) followed by '[Script Info]' — BOM-prefixed ASS/SSA file",
+        "weight": 60,
+        "required": false
+      }
+    ],
+    "matchMode": "weighted",
+    "MinimumScore": 60,
+    "Strength": "Strong",
+    "EntropyHint": {
+      "min": 3.5,
+      "max": 5.5,
+      "note": "INI-style text with style definitions, dialogue lines, and override tags; entropy reflects structured natural language with markup."
+    },
+    "validation": {
+      "minFileSize": 13,
+      "maxSignatureOffset": 4,
+      "expression": "STRING_ASCII(0, 13) == '[Script Info]' || STRING_ASCII(3, 13) == '[Script Info]'",
+      "description": "File must start with '[Script Info]' section header (optionally preceded by UTF-8 BOM)."
+    }
+  },
+
+  "variables": {
+    "sectionHeader":  { "offset": 0, "length": 13, "type": "ascii" },
+    "postHeaderByte": { "offset": 13, "length": 1,  "type": "uint8" }
+  },
+
+  "blocks": [
+    {
+      "type": "signature",
+      "name": "[Script Info] Header",
+      "offset": 0,
+      "length": 13,
+      "color": "#EF5350",
+      "opacity": 0.8,
+      "description": "13-byte ASCII string '[Script Info]' (0x5B 0x53 0x63 0x72 0x69 0x70 0x74 0x20 0x49 0x6E 0x66 0x6F 0x5D) — mandatory first section of every ASS/SSA file containing Title, ScriptType, PlayResX/Y, and other metadata.",
+      "storeAs": "sectionHeader",
+      "valueType": "ascii"
+    },
+    {
+      "type": "field",
+      "name": "Newline After Header",
+      "offset": 13,
+      "length": 1,
+      "color": "#EF9A9A",
+      "opacity": 0.5,
+      "description": "Newline byte after [Script Info]: 0x0D (CR, followed by LF) or 0x0A (LF). The Script Info section body follows on subsequent lines.",
+      "storeAs": "postHeaderByte",
+      "valueType": "uint8",
+      "valueMap": {
+        "13": "0x0D — Carriage Return (CRLF line ending)",
+        "10": "0x0A — Line Feed (LF line ending)"
+      }
+    },
+    {
+      "type": "metadata",
+      "name": "Script Info Section",
+      "offset": "variable",
+      "length": "variable",
+      "color": "#E57373",
+      "opacity": 0.5,
+      "description": "Key-value metadata: Title, ScriptType (v4.00+ for ASS, v4.00 for SSA), WrapStyle, ScaledBorderAndShadow, PlayResX, PlayResY, YCbCr Matrix, Collisions, Timer."
+    },
+    {
+      "type": "metadata",
+      "name": "Styles Section",
+      "offset": "variable",
+      "length": "variable",
+      "color": "#F48FB1",
+      "opacity": 0.5,
+      "description": "[V4+ Styles] (ASS) or [V4 Styles] (SSA) section: Format line defining field order, then Style lines with Name, Fontname, Fontsize, PrimaryColour, SecondaryColour, OutlineColour, BackColour, Bold, Italic, BorderStyle, Outline, Shadow, Alignment, MarginL/R/V, Encoding."
+    },
+    {
+      "type": "metadata",
+      "name": "Events Section",
+      "offset": "variable",
+      "length": "variable",
+      "color": "#CE93D8",
+      "opacity": 0.5,
+      "description": "[Events] section: Format line, then Dialogue/Comment lines with Layer, Start, End, Style, Name, MarginL/R/V, Effect, Text. Text field supports override tags: {\\b1}, {\\i1}, {\\pos(x,y)}, {\\move(x1,y1,x2,y2)}, {\\fad(in,out)}, {\\clip()}, {\\t()}, {\\an8}, {\\fn}, {\\fs}, {\\1c&HBBGGRR&}."
+    }
+  ],
+
+  "assertions": [
+    {
+      "name": "ScriptInfoHeader",
+      "expression": "STRING_ASCII(0, 13) == '[Script Info]' || STRING_ASCII(3, 13) == '[Script Info]'",
+      "severity": "error",
+      "message": "File does not start with '[Script Info]' section header; this is not a valid ASS/SSA subtitle file."
+    },
+    {
+      "name": "PostHeaderNewline",
+      "expression": "UINT8(0) == 0xEF || UINT8(13) == 0x0A || UINT8(13) == 0x0D",
+      "severity": "warning",
+      "message": "Expected newline (LF or CRLF) after '[Script Info]' header; the section body may not parse correctly."
+    },
+    {
+      "name": "FileSizeMinimum",
+      "expression": "FILE_SIZE >= 50",
+      "severity": "warning",
+      "message": "File is very small (< 50 bytes); a valid ASS/SSA file requires at minimum [Script Info] with ScriptType and at least one [Events] Dialogue line."
+    }
+  ],
+
+  "navigation": {
+    "bookmarks": [
+      { "name": "[Script Info]",    "offset": 0,  "description": "Script Info section header — 13 bytes ASCII" },
+      { "name": "Post-Header Byte", "offset": 13, "description": "Newline after section header" }
+    ]
+  },
+
+  "inspector": {
+    "badge": "ASS",
+    "primaryField": "sectionHeader",
+    "showQualityScore": true,
+    "groups": [
+      {
+        "name": "File Header",
+        "fields": [ "sectionHeader", "postHeaderByte" ]
+      }
+    ]
+  },
+
+  "exportTemplates": [
+    {
+      "name": "ASS Header Summary",
+      "format": "text",
+      "template": "Advanced SubStation Alpha\n  Section Header : {sectionHeader}\n  Post-Header    : {postHeaderByte} ({postHeaderByte_mapped})"
+    },
+    {
+      "name": "ASS JSON Report",
+      "format": "json",
+      "template": "{ \"format\": \"ASS\", \"sectionHeader\": \"{sectionHeader}\", \"postHeaderByte\": {postHeaderByte} }"
+    }
+  ],
+
+  "forensic": {
+    "category": "MediaSubtitle",
+    "riskLevel": "low",
+    "suspiciousPatterns": [
+      { "pattern": "OverrideTagAbuse",     "description": "Excessive or deeply nested override tags ({\\t(...)}, {\\clip(...)}) may cause rendering performance issues or crashes in subtitle renderers." },
+      { "pattern": "ExternalFontReference", "description": "Style definitions referencing unusual font names may indicate an attempt to trigger font loading vulnerabilities in the host application." }
+    ]
+  },
+
+  "aiHints": {
+    "analysisContext": "ASS is an INI-style text subtitle format with three mandatory sections: [Script Info], [V4+ Styles], and [Events]. The '[Script Info]' header at offset 0 provides strong detection. ASS is the dominant format for anime fansubbing due to its rich override tag system for positioning, animation, clipping, and karaoke. Colors use &HAABBGGRR& (BGR, not RGB).",
+    "suggestedInspections": [
+      "Check the ScriptType field in [Script Info] to distinguish ASS (v4.00+) from SSA (v4.00) and determine available features.",
+      "Parse PlayResX and PlayResY to identify the virtual canvas resolution used for absolute positioning in override tags.",
+      "Scan [V4+ Styles] for the number of defined styles and their font/color properties to assess typesetting complexity.",
+      "Search for complex override tags ({\\move}, {\\clip}, {\\t}, {\\fad}) in [Events] Dialogue lines to evaluate animation usage.",
+      "Verify that all Style names referenced in Dialogue lines exist in the [V4+ Styles] section to detect broken style references."
+    ]
+  },
+
+  "TechnicalDetails": {
+    "specification": "ASS format specification (community-maintained): http://www.tcax.org/docs/ass-specs.htm",
+    "endianness": "N/A (text format)",
+    "encoding": "UTF-8 (modern), Shift_JIS or other legacy encodings in older files",
+    "scriptTypes": {
+      "v4.00+": "Advanced SubStation Alpha (ASS) — [V4+ Styles], extended override tags",
+      "v4.00": "SubStation Alpha (SSA) — [V4 Styles], limited override tags"
+    },
+    "colorFormat": "&HAABBGGRR& — hexadecimal, Alpha-Blue-Green-Red order (note: BGR, not RGB)",
+    "overrideTags": "Per-character styling: {\\b}, {\\i}, {\\fn}, {\\fs}, {\\1c}, {\\pos}, {\\move}, {\\fad}, {\\clip}, {\\t}, {\\an}, {\\org}, {\\frz}, {\\fax}, {\\fay}",
+    "notes": "Aegisub is the de facto editor. libass is the reference renderer. xy-VSFilter is the legacy DirectShow renderer. Color ordering (BGR) is a common source of bugs when converting to/from other formats."
+  },
+
+  "QualityMetrics": {
+    "CompletenessScore": 90,
+    "DocumentationLevel": "comprehensive",
+    "BlocksDefined": 5,
+    "ValidationRules": 3,
+    "LastUpdated": "2026-04-14",
+    "PriorityFormat": true,
+    "AutoRefined": false
+  }
+}

--- a/Sources/Core/WpfHexEditor.Core.Definitions/FormatDefinitions/Subtitles/SRT.whfmt
+++ b/Sources/Core/WpfHexEditor.Core.Definitions/FormatDefinitions/Subtitles/SRT.whfmt
@@ -1,0 +1,217 @@
+{
+  "diffMode": "text",
+  "formatName": "SubRip Subtitle",
+  "version": "1.0",
+  "extensions": [ ".srt" ],
+  "description": "SRT (SubRip) is the most widely used plain-text subtitle format; each entry consists of a sequential integer, a timestamp range (HH:MM:SS,mmm --> HH:MM:SS,mmm), and one or more lines of subtitle text supporting basic HTML tags (<b>, <i>, <u>, <font>), separated by blank lines. Encoding is typically UTF-8 with optional BOM.",
+  "category": "Subtitles",
+  "author": "WPFHexaEditor Team",
+  "preferredEditor": "text-editor",
+  "MimeTypes": [ "text/plain", "application/x-subrip" ],
+  "UseCases": [
+    "Movie and TV show subtitle files for media players",
+    "Video accessibility and closed captioning workflows",
+    "Subtitle translation and localization pipelines",
+    "Streaming platform caption ingestion (Netflix, YouTube)"
+  ],
+  "software": [
+    { "name": "VLC",              "role": "consumer" },
+    { "name": "MPC-HC",           "role": "consumer" },
+    { "name": "Subtitle Edit",    "role": "producer/consumer" },
+    { "name": "Aegisub",          "role": "producer/consumer" },
+    { "name": "HandBrake",        "role": "consumer" },
+    { "name": "FFmpeg (ffprobe)", "role": "consumer" }
+  ],
+  "references": {
+    "specifications": [ "SubRip SRT Format (de facto standard, no formal specification)" ],
+    "WebLinks": [ "https://en.wikipedia.org/wiki/SubRip" ]
+  },
+  "formatRelationships": {
+    "relatedFormats": [ "VTT (WebVTT)", "ASS (Advanced SubStation Alpha)", "SSA (SubStation Alpha)", "SUB (MicroDVD)" ],
+    "container": null,
+    "notes": "SRT is the simplest subtitle format; it can be converted to/from VTT, ASS, and other formats with minimal loss for basic styling."
+  },
+
+  "detection": {
+    "signatures": [
+      {
+        "value": "310D0A",
+        "offset": 0,
+        "label": "'1\\r\\n' — first SRT sequence number with CRLF line ending",
+        "weight": 25,
+        "required": false
+      },
+      {
+        "value": "310A",
+        "offset": 0,
+        "label": "'1\\n' — first SRT sequence number with LF line ending",
+        "weight": 25,
+        "required": false
+      },
+      {
+        "value": "EFBBBF31",
+        "offset": 0,
+        "label": "UTF-8 BOM (EF BB BF) followed by '1' — BOM-prefixed SRT file",
+        "weight": 35,
+        "required": false
+      }
+    ],
+    "matchMode": "weighted",
+    "MinimumScore": 25,
+    "Strength": "Weak",
+    "EntropyHint": {
+      "min": 3.0,
+      "max": 5.5,
+      "note": "Plain text subtitle content with timestamps and short dialogue lines; entropy is typical of natural language UTF-8 text."
+    },
+    "validation": {
+      "minFileSize": 2,
+      "maxSignatureOffset": 4
+    }
+  },
+
+  "variables": {
+    "firstByte":  { "offset": 0, "length": 1, "type": "uint8" },
+    "secondByte": { "offset": 1, "length": 1, "type": "uint8" },
+    "thirdByte":  { "offset": 2, "length": 1, "type": "uint8" }
+  },
+
+  "blocks": [
+    {
+      "type": "field",
+      "name": "First Byte",
+      "offset": 0,
+      "length": 1,
+      "color": "#42A5F5",
+      "opacity": 0.6,
+      "description": "First byte of the file: 0x31 ('1') for the first sequence number, or 0xEF for the start of a UTF-8 BOM.",
+      "storeAs": "firstByte",
+      "valueType": "uint8",
+      "valueMap": {
+        "49": "'1' — first subtitle sequence number",
+        "239": "0xEF — UTF-8 BOM start byte"
+      }
+    },
+    {
+      "type": "field",
+      "name": "Second Byte",
+      "offset": 1,
+      "length": 1,
+      "color": "#66BB6A",
+      "opacity": 0.5,
+      "description": "Second byte: 0x0D (CR) or 0x0A (LF) after sequence number '1', or 0xBB for BOM continuation.",
+      "storeAs": "secondByte",
+      "valueType": "uint8",
+      "valueMap": {
+        "13": "0x0D — Carriage Return (CRLF line ending)",
+        "10": "0x0A — Line Feed (LF line ending)",
+        "187": "0xBB — UTF-8 BOM continuation byte"
+      }
+    },
+    {
+      "type": "metadata",
+      "name": "Subtitle Entries",
+      "offset": "variable",
+      "length": "variable",
+      "color": "#AB47BC",
+      "opacity": 0.5,
+      "description": "Sequential subtitle entries each consisting of: sequence number (integer), timestamp line (HH:MM:SS,mmm --> HH:MM:SS,mmm), one or more lines of subtitle text, and a blank line separator."
+    }
+  ],
+
+  "assertions": [
+    {
+      "name": "FirstByteIsSequenceOrBOM",
+      "expression": "UINT8(0) == 0x31 || UINT8(0) == 0xEF",
+      "severity": "error",
+      "message": "First byte is neither '1' (0x31) nor UTF-8 BOM start (0xEF); file may not be a valid SRT subtitle."
+    },
+    {
+      "name": "BOMContinuationValid",
+      "expression": "UINT8(0) != 0xEF || (UINT8(1) == 0xBB && UINT8(2) == 0xBF)",
+      "severity": "error",
+      "message": "UTF-8 BOM is incomplete; expected EF BB BF but continuation bytes do not match."
+    },
+    {
+      "name": "FileSizeMinimum",
+      "expression": "FILE_SIZE >= 10",
+      "severity": "warning",
+      "message": "File is extremely small (< 10 bytes); a valid SRT file requires at least one complete subtitle entry with sequence number, timestamp, and text."
+    }
+  ],
+
+  "navigation": {
+    "bookmarks": [
+      { "name": "File Start / BOM",      "offset": 0, "description": "First byte: sequence number '1' or UTF-8 BOM" },
+      { "name": "First Timestamp Region", "offset": 2, "description": "Approximate start of the first timestamp line (HH:MM:SS,mmm --> HH:MM:SS,mmm)" }
+    ]
+  },
+
+  "inspector": {
+    "badge": "SRT",
+    "primaryField": "firstByte",
+    "showQualityScore": true,
+    "groups": [
+      {
+        "name": "File Header",
+        "fields": [ "firstByte", "secondByte" ]
+      },
+      {
+        "name": "Format Info",
+        "fields": [ "thirdByte" ]
+      }
+    ]
+  },
+
+  "exportTemplates": [
+    {
+      "name": "SRT Header Summary",
+      "format": "text",
+      "template": "SubRip Subtitle (SRT)\n  First Byte : {firstByte} ({firstByte_mapped})\n  Second Byte: {secondByte} ({secondByte_mapped})"
+    },
+    {
+      "name": "SRT JSON Report",
+      "format": "json",
+      "template": "{ \"format\": \"SRT\", \"firstByte\": {firstByte}, \"secondByte\": {secondByte} }"
+    }
+  ],
+
+  "forensic": {
+    "category": "MediaSubtitle",
+    "riskLevel": "low",
+    "suspiciousPatterns": [
+      { "pattern": "EmbeddedScriptTags",   "description": "SRT text lines may contain HTML-like tags; malformed or unexpected tags could indicate injection attempts in vulnerable players." },
+      { "pattern": "ExcessiveEntryCount",   "description": "An abnormally high number of subtitle entries may indicate a fuzzing artifact or corrupted file." }
+    ]
+  },
+
+  "aiHints": {
+    "analysisContext": "SRT is a plain-text subtitle format with no binary structure. Each entry is: sequence number, timestamp range (HH:MM:SS,mmm --> HH:MM:SS,mmm), subtitle text, blank line. Detection relies on the first byte being '1' or a UTF-8 BOM, making signature matching inherently weak.",
+    "suggestedInspections": [
+      "Check whether the file starts with a UTF-8 BOM (EF BB BF) and note the encoding for correct text rendering.",
+      "Verify that the first non-BOM content is a sequence number '1' followed by a valid timestamp line.",
+      "Scan for HTML formatting tags (<b>, <i>, <u>, <font>) in subtitle text lines to assess styling complexity.",
+      "Validate timestamp ordering to ensure all entries have non-overlapping, monotonically increasing time ranges.",
+      "Check for encoding anomalies — mixed UTF-8 and Latin-1 bytes can cause garbled subtitle display."
+    ]
+  },
+
+  "TechnicalDetails": {
+    "specification": "No formal specification; de facto standard defined by SubRip tool behavior and widespread player support.",
+    "endianness": "N/A (text format)",
+    "encoding": "UTF-8 (with optional BOM), or legacy ANSI/Latin-1/Windows-1252",
+    "timestampFormat": "HH:MM:SS,mmm --> HH:MM:SS,mmm (comma as decimal separator, not period)",
+    "htmlTags": "Supported: <b>, <i>, <u>, <font color=\"...\">. Player support varies.",
+    "notes": "SRT has no header or footer; the file is purely sequential entries. Empty lines between entries are mandatory separators."
+  },
+
+  "QualityMetrics": {
+    "CompletenessScore": 88,
+    "DocumentationLevel": "comprehensive",
+    "BlocksDefined": 3,
+    "ValidationRules": 3,
+    "LastUpdated": "2026-04-14",
+    "PriorityFormat": true,
+    "AutoRefined": false
+  }
+}

--- a/Sources/Core/WpfHexEditor.Core.Definitions/FormatDefinitions/Subtitles/SUP.whfmt
+++ b/Sources/Core/WpfHexEditor.Core.Definitions/FormatDefinitions/Subtitles/SUP.whfmt
@@ -1,0 +1,254 @@
+{
+  "diffMode": "binary",
+  "formatName": "PGS Blu-ray Subtitle",
+  "version": "1.0",
+  "extensions": [ ".sup" ],
+  "description": "PGS (Presentation Graphic Stream) is the bitmap-based subtitle format used on Blu-ray discs; each display event is a sequence of segments starting with the 'PG' magic (0x50 0x47), containing RLE-encoded palette-indexed images with 90 kHz PTS/DTS timestamps, palette definitions (PDS), object bitmaps (ODS), composition control (PCS), window definitions (WDS), and end-of-display markers.",
+  "category": "Subtitles",
+  "author": "WPFHexaEditor Team",
+  "preferredEditor": "hex-editor",
+  "MimeTypes": [ "application/x-pgs" ],
+  "UseCases": [
+    "Blu-ray disc subtitle tracks (HDMV specification)",
+    "MKV-embedded PGS subtitle streams extracted from Blu-ray rips",
+    "Forced subtitle overlay for foreign language segments",
+    "Subtitle extraction and OCR conversion (PGS to SRT via Tesseract)"
+  ],
+  "software": [
+    { "name": "BDSup2Sub",         "role": "consumer (convert SUP to SRT/VobSub)" },
+    { "name": "mkvtoolnix",        "role": "producer/consumer (mux SUP into MKV)" },
+    { "name": "Subtitle Edit",     "role": "consumer (OCR + edit)" },
+    { "name": "PGSEdit",           "role": "producer/consumer" },
+    { "name": "FFmpeg",            "role": "consumer (extract from Blu-ray/MKV)" }
+  ],
+  "references": {
+    "specifications": [ "Blu-ray Disc Association HDMV Presentation Graphic Stream specification" ],
+    "WebLinks": [ "https://en.wikipedia.org/wiki/Presentation_Graphic_Stream", "https://blog.thescorpius.com/index.php/2017/07/15/presentation-graphic-stream-sup-files-bluray-subtitle-format/" ]
+  },
+  "formatRelationships": {
+    "relatedFormats": [ "VobSub (.sub/.idx — DVD bitmap subtitles)", "SRT (text — via OCR conversion)", "HDMV Interactive Graphics" ],
+    "container": "Blu-ray HDMV transport stream, MKV (Matroska)",
+    "notes": "PGS is purely bitmap-based — there is no embedded text. Converting to text formats (SRT, VTT) requires OCR. PGS is part of the Blu-ray HDMV specification alongside Interactive Graphics (IG)."
+  },
+
+  "detection": {
+    "signatures": [
+      {
+        "value": "5047",
+        "offset": 0,
+        "label": "'PG' — Presentation Graphic Stream segment header magic",
+        "weight": 60,
+        "required": true
+      }
+    ],
+    "matchMode": "weighted",
+    "MinimumScore": 60,
+    "Strength": "Strong",
+    "EntropyHint": {
+      "min": 2.0,
+      "max": 6.5,
+      "note": "RLE-encoded bitmap data varies widely in entropy; simple solid-color subtitles have low entropy while anti-aliased or complex glyphs approach higher values."
+    },
+    "validation": {
+      "minFileSize": 13,
+      "maxSignatureOffset": 0,
+      "expression": "STRING_ASCII(0, 2) == 'PG'",
+      "description": "First two bytes must be 'PG' (0x50 0x47) — the PGS segment header magic."
+    }
+  },
+
+  "variables": {
+    "magic":        { "offset": 0,  "length": 2, "type": "ascii" },
+    "pts":          { "offset": 2,  "length": 4, "type": "uint32be" },
+    "dts":          { "offset": 6,  "length": 4, "type": "uint32be" },
+    "segmentType":  { "offset": 10, "length": 1, "type": "uint8" },
+    "segmentSize":  { "offset": 11, "length": 2, "type": "uint16be" }
+  },
+
+  "blocks": [
+    {
+      "type": "signature",
+      "name": "PG Magic",
+      "offset": 0,
+      "length": 2,
+      "color": "#FF7043",
+      "opacity": 0.9,
+      "description": "2-byte ASCII magic 'PG' (0x50 0x47) identifying the start of a Presentation Graphic Stream segment.",
+      "storeAs": "magic",
+      "valueType": "ascii"
+    },
+    {
+      "type": "field",
+      "name": "Presentation Timestamp (PTS)",
+      "offset": 2,
+      "length": 4,
+      "color": "#FFA726",
+      "opacity": 0.7,
+      "description": "32-bit big-endian Presentation TimeStamp in 90 kHz clock units; divide by 90000 to get seconds. Indicates when this subtitle segment should be displayed.",
+      "storeAs": "pts",
+      "valueType": "uint32",
+      "endianness": "big"
+    },
+    {
+      "type": "field",
+      "name": "Decoding Timestamp (DTS)",
+      "offset": 6,
+      "length": 4,
+      "color": "#FFB74D",
+      "opacity": 0.6,
+      "description": "32-bit big-endian Decoding TimeStamp in 90 kHz clock units; typically 0 for PGS since decode and present happen simultaneously.",
+      "storeAs": "dts",
+      "valueType": "uint32",
+      "endianness": "big"
+    },
+    {
+      "type": "field",
+      "name": "Segment Type",
+      "offset": 10,
+      "length": 1,
+      "color": "#FF8A65",
+      "opacity": 0.8,
+      "description": "Segment type identifier byte determining the content and structure of the segment data payload.",
+      "storeAs": "segmentType",
+      "valueType": "uint8",
+      "valueMap": {
+        "20": "0x14 — PDS (Palette Definition Segment): 256-entry YCbCr+Alpha palette",
+        "21": "0x15 — ODS (Object Definition Segment): RLE-encoded bitmap data",
+        "22": "0x16 — PCS (Presentation Composition Segment): display control and object placement",
+        "23": "0x17 — WDS (Window Definition Segment): display area rectangle",
+        "128": "0x80 — END (End of Display Set): marks completion of a subtitle epoch"
+      }
+    },
+    {
+      "type": "field",
+      "name": "Segment Size",
+      "offset": 11,
+      "length": 2,
+      "color": "#FFAB91",
+      "opacity": 0.6,
+      "description": "16-bit big-endian size in bytes of the segment data payload immediately following this header. END segments typically have size 0.",
+      "storeAs": "segmentSize",
+      "valueType": "uint16",
+      "endianness": "big"
+    },
+    {
+      "type": "metadata",
+      "name": "Segment Data",
+      "offset": 13,
+      "length": "variable",
+      "color": "#FFCCBC",
+      "opacity": 0.4,
+      "description": "Variable-length segment payload: PDS contains palette entries (Y, Cr, Cb, Alpha per index); ODS contains RLE-encoded 8-bit palette-indexed bitmap; PCS contains composition state, object positions, and palette references; WDS contains window rectangle coordinates."
+    }
+  ],
+
+  "assertions": [
+    {
+      "name": "PGMagicValid",
+      "expression": "UINT8(0) == 0x50 && UINT8(1) == 0x47",
+      "severity": "error",
+      "message": "First two bytes are not 'PG' (0x50 0x47); this is not a valid PGS Blu-ray subtitle file."
+    },
+    {
+      "name": "SegmentTypeKnown",
+      "expression": "UINT8(10) == 0x14 || UINT8(10) == 0x15 || UINT8(10) == 0x16 || UINT8(10) == 0x17 || UINT8(10) == 0x80",
+      "severity": "warning",
+      "message": "First segment type byte is not a recognized PGS segment type (expected PDS=0x14, ODS=0x15, PCS=0x16, WDS=0x17, END=0x80)."
+    },
+    {
+      "name": "FileSizeMinimum",
+      "expression": "FILE_SIZE >= 13",
+      "severity": "error",
+      "message": "File is too small (< 13 bytes) to contain a complete PGS segment header (2B magic + 4B PTS + 4B DTS + 1B type + 2B size)."
+    },
+    {
+      "name": "SegmentSizeConsistent",
+      "expression": "UINT8(10) == 0x80 || UINT16BE(11) > 0",
+      "severity": "warning",
+      "message": "Non-END segment has zero data size; PDS, ODS, PCS, and WDS segments should contain payload data."
+    }
+  ],
+
+  "navigation": {
+    "bookmarks": [
+      { "name": "PG Magic",       "offset": 0,  "description": "'PG' segment header magic (2 bytes)" },
+      { "name": "PTS",            "offset": 2,  "description": "Presentation TimeStamp (4 bytes, uint32 BE, 90kHz)" },
+      { "name": "DTS",            "offset": 6,  "description": "Decoding TimeStamp (4 bytes, uint32 BE, 90kHz)" },
+      { "name": "Segment Type",   "offset": 10, "description": "Segment type: PDS/ODS/PCS/WDS/END" },
+      { "name": "Segment Size",   "offset": 11, "description": "Payload size (2 bytes, uint16 BE)" },
+      { "name": "Segment Data",   "offset": 13, "description": "Start of segment payload data" }
+    ]
+  },
+
+  "inspector": {
+    "badge": "PGS",
+    "primaryField": "magic",
+    "showQualityScore": true,
+    "groups": [
+      {
+        "name": "Segment Header",
+        "fields": [ "magic", "pts", "dts", "segmentType", "segmentSize" ]
+      }
+    ]
+  },
+
+  "exportTemplates": [
+    {
+      "name": "PGS Segment Header Summary",
+      "format": "text",
+      "template": "PGS Blu-ray Subtitle\n  Magic        : {magic}\n  PTS          : {pts} (÷90000 = seconds)\n  DTS          : {dts}\n  Segment Type : {segmentType} ({segmentType_mapped})\n  Segment Size : {segmentSize} bytes"
+    },
+    {
+      "name": "PGS JSON Report",
+      "format": "json",
+      "template": "{ \"format\": \"PGS\", \"magic\": \"{magic}\", \"pts\": {pts}, \"dts\": {dts}, \"segmentType\": {segmentType}, \"segmentSize\": {segmentSize} }"
+    }
+  ],
+
+  "forensic": {
+    "category": "MediaSubtitle",
+    "riskLevel": "low",
+    "suspiciousPatterns": [
+      { "pattern": "OversizedBitmap",       "description": "ODS segments with unusually large RLE-decoded bitmap dimensions (exceeding 1920x1080) may indicate a malformed or crafted file." },
+      { "pattern": "MissingEndSegment",     "description": "Display sets without a terminating END segment (0x80) indicate a truncated file or incomplete Blu-ray rip." },
+      { "pattern": "ExcessivePaletteSwaps", "description": "Frequent PDS segments with different palettes may indicate steganographic data hidden in palette index assignments." }
+    ]
+  },
+
+  "aiHints": {
+    "analysisContext": "PGS is a binary bitmap-based subtitle format from the Blu-ray HDMV specification. Each segment starts with 'PG' (2B) + PTS (4B BE) + DTS (4B BE) + type (1B) + size (2B) = 13-byte header. Segment types: PDS (0x14, palette), ODS (0x15, RLE bitmap), PCS (0x16, composition), WDS (0x17, window), END (0x80). A display set is an epoch of PCS+WDS+PDS+ODS+END. No text content — OCR required for text extraction.",
+    "suggestedInspections": [
+      "Parse the first segment header to extract PTS and convert from 90kHz clock to human-readable timestamp (PTS / 90000 = seconds).",
+      "Identify the segment type of the first segment — a PCS (0x16) at epoch start indicates a new display set beginning.",
+      "Count the total number of display sets by scanning for PCS segments with composition_state = epoch_start (0x80).",
+      "Check ODS segments for bitmap dimensions to verify they fit within the expected 1920x1080 Blu-ray resolution.",
+      "Verify each display set is properly terminated with an END segment (0x80) to detect truncated or corrupted files."
+    ]
+  },
+
+  "TechnicalDetails": {
+    "specification": "Blu-ray Disc Association HDMV specification — Presentation Graphic Stream (not publicly available; reverse-engineered documentation widely used)",
+    "endianness": "big-endian (all multi-byte fields)",
+    "maxResolution": "1920x1080 (Full HD Blu-ray)",
+    "clockRate": "90 kHz (PTS/DTS values in 90000 ticks per second, standard MPEG-2 clock)",
+    "segmentTypes": {
+      "0x14": "PDS — Palette Definition Segment: up to 256 entries, each 5 bytes (index, Y, Cr, Cb, Alpha)",
+      "0x15": "ODS — Object Definition Segment: RLE-encoded 8-bit palette-indexed bitmap",
+      "0x16": "PCS — Presentation Composition Segment: width, height, framerate, composition_number, composition_state (normal/acquisition/epoch_start), palette_id, object list",
+      "0x17": "WDS — Window Definition Segment: window count, then (window_id, x, y, width, height) per window",
+      "0x80": "END — End of Display Set: zero-length payload, marks completion of current subtitle epoch"
+    },
+    "rleEncoding": "Palette-indexed 8-bit pixels; run-length encoded with special escape sequences for line breaks and color runs",
+    "notes": "PGS is purely bitmap — no text is stored. Converting to SRT/VTT requires OCR (e.g., Tesseract via PGS2SRT or Subtitle Edit). Maximum 256 palette colors per PDS. Typically the first segment of a display set is PCS."
+  },
+
+  "QualityMetrics": {
+    "CompletenessScore": 92,
+    "DocumentationLevel": "comprehensive",
+    "BlocksDefined": 6,
+    "ValidationRules": 4,
+    "LastUpdated": "2026-04-14",
+    "PriorityFormat": true,
+    "AutoRefined": false
+  }
+}

--- a/Sources/Core/WpfHexEditor.Core.Definitions/FormatDefinitions/Subtitles/VTT.whfmt
+++ b/Sources/Core/WpfHexEditor.Core.Definitions/FormatDefinitions/Subtitles/VTT.whfmt
@@ -1,0 +1,213 @@
+{
+  "diffMode": "text",
+  "formatName": "WebVTT Subtitle",
+  "version": "1.0",
+  "extensions": [ ".vtt" ],
+  "description": "WebVTT (Web Video Text Tracks) is the W3C standard subtitle and caption format for HTML5 video; files must begin with the ASCII string 'WEBVTT' followed by a space/tab/newline or EOF, then cue blocks with timestamps (HH:MM:SS.mmm --> HH:MM:SS.mmm), optional cue settings, STYLE/REGION/NOTE blocks, and CSS ::cue pseudo-element styling.",
+  "category": "Subtitles",
+  "author": "WPFHexaEditor Team",
+  "preferredEditor": "text-editor",
+  "MimeTypes": [ "text/vtt" ],
+  "UseCases": [
+    "HTML5 <track> element for video captions and subtitles in web browsers",
+    "Live streaming subtitle delivery (HLS, DASH)",
+    "YouTube and Twitch closed caption files",
+    "Web accessibility compliance (WCAG 2.1 Level AA/AAA)"
+  ],
+  "software": [
+    { "name": "Chrome/Firefox/Safari", "role": "consumer (native <track> support)" },
+    { "name": "VLC",                   "role": "consumer" },
+    { "name": "Subtitle Edit",         "role": "producer/consumer" },
+    { "name": "FFmpeg",                "role": "producer/consumer" },
+    { "name": "YouTube Studio",        "role": "producer/consumer" }
+  ],
+  "references": {
+    "specifications": [ "W3C WebVTT: The Web Video Text Tracks Format (https://www.w3.org/TR/webvtt1/)" ],
+    "WebLinks": [ "https://en.wikipedia.org/wiki/WebVTT", "https://developer.mozilla.org/en-US/docs/Web/API/WebVTT_API" ]
+  },
+  "formatRelationships": {
+    "relatedFormats": [ "SRT (SubRip)", "TTML (Timed Text Markup Language)", "CEA-608/708 Captions" ],
+    "container": null,
+    "notes": "WebVTT evolved from SRT with added features: cue settings, CSS styling, regions, and metadata notes. Most SRT files can be trivially converted to VTT."
+  },
+
+  "detection": {
+    "signatures": [
+      {
+        "value": "574542565454",
+        "offset": 0,
+        "label": "'WEBVTT' — Web Video Text Tracks mandatory file header",
+        "weight": 60,
+        "required": true
+      },
+      {
+        "value": "EFBBBF574542565454",
+        "offset": 0,
+        "label": "UTF-8 BOM (EF BB BF) followed by 'WEBVTT' — BOM-prefixed WebVTT file",
+        "weight": 60,
+        "required": false
+      }
+    ],
+    "matchMode": "weighted",
+    "MinimumScore": 60,
+    "Strength": "Strong",
+    "EntropyHint": {
+      "min": 3.0,
+      "max": 5.5,
+      "note": "Plain text with timestamps, cue settings, and natural language content; entropy is comparable to other text-based subtitle formats."
+    },
+    "validation": {
+      "minFileSize": 6,
+      "maxSignatureOffset": 4,
+      "expression": "STRING_ASCII(0, 6) == 'WEBVTT' || STRING_ASCII(3, 6) == 'WEBVTT'",
+      "description": "File must begin with 'WEBVTT' (optionally preceded by UTF-8 BOM)."
+    }
+  },
+
+  "variables": {
+    "magic":        { "offset": 0, "length": 6, "type": "ascii" },
+    "postHeader":   { "offset": 6, "length": 1, "type": "uint8" }
+  },
+
+  "blocks": [
+    {
+      "type": "signature",
+      "name": "WEBVTT Header",
+      "offset": 0,
+      "length": 6,
+      "color": "#26A69A",
+      "opacity": 0.8,
+      "description": "6-byte ASCII magic string 'WEBVTT' (0x57 0x45 0x42 0x56 0x54 0x54) — mandatory first bytes of every WebVTT file per W3C specification.",
+      "storeAs": "magic",
+      "valueType": "ascii"
+    },
+    {
+      "type": "field",
+      "name": "Post-Header Byte",
+      "offset": 6,
+      "length": 1,
+      "color": "#4DB6AC",
+      "opacity": 0.6,
+      "description": "Byte immediately after 'WEBVTT': must be 0x0A (LF), 0x0D (CR), 0x20 (space), or 0x09 (tab). Space/tab indicates an optional header description follows on the same line.",
+      "storeAs": "postHeader",
+      "valueType": "uint8",
+      "valueMap": {
+        "10": "0x0A — Line Feed (header-only, no description)",
+        "13": "0x0D — Carriage Return",
+        "32": "0x20 — Space (header description follows)",
+        "9":  "0x09 — Tab (header description follows)"
+      }
+    },
+    {
+      "type": "metadata",
+      "name": "Cue Blocks",
+      "offset": "variable",
+      "length": "variable",
+      "color": "#80CBC4",
+      "opacity": 0.5,
+      "description": "Sequence of cue blocks: optional cue ID, timestamp line (HH:MM:SS.mmm --> HH:MM:SS.mmm with optional settings: position, line, align, size, vertical), and cue payload text with optional voice (<v>), class (<c>), bold (<b>), italic (<i>) tags."
+    },
+    {
+      "type": "metadata",
+      "name": "STYLE / REGION / NOTE Blocks",
+      "offset": "variable",
+      "length": "variable",
+      "color": "#B2DFDB",
+      "opacity": 0.4,
+      "description": "Optional STYLE blocks (embedded CSS for ::cue pseudo-element), REGION blocks (spatial positioning definitions), and NOTE blocks (metadata comments not rendered to the user)."
+    }
+  ],
+
+  "assertions": [
+    {
+      "name": "MagicIsWEBVTT",
+      "expression": "STRING_ASCII(0, 6) == 'WEBVTT' || STRING_ASCII(3, 6) == 'WEBVTT'",
+      "severity": "error",
+      "message": "File does not start with 'WEBVTT' (with or without BOM); this is not a valid WebVTT file per the W3C specification."
+    },
+    {
+      "name": "PostHeaderByteValid",
+      "expression": "UINT8(0) == 0xEF || UINT8(6) == 0x0A || UINT8(6) == 0x0D || UINT8(6) == 0x20 || UINT8(6) == 0x09 || FILE_SIZE == 6",
+      "severity": "warning",
+      "message": "Byte after 'WEBVTT' header is not a valid delimiter (space, tab, newline, or EOF); some parsers may reject this file."
+    },
+    {
+      "name": "FileSizeMinimum",
+      "expression": "FILE_SIZE >= 6",
+      "severity": "error",
+      "message": "File is smaller than 6 bytes; cannot contain the mandatory 'WEBVTT' header string."
+    }
+  ],
+
+  "navigation": {
+    "bookmarks": [
+      { "name": "WEBVTT Magic",      "offset": 0, "description": "'WEBVTT' 6-byte ASCII header" },
+      { "name": "Post-Header Byte",  "offset": 6, "description": "Delimiter after header: space, tab, or newline" }
+    ]
+  },
+
+  "inspector": {
+    "badge": "VTT",
+    "primaryField": "magic",
+    "showQualityScore": true,
+    "groups": [
+      {
+        "name": "File Header",
+        "fields": [ "magic", "postHeader" ]
+      }
+    ]
+  },
+
+  "exportTemplates": [
+    {
+      "name": "WebVTT Header Summary",
+      "format": "text",
+      "template": "WebVTT Subtitle\n  Magic       : {magic}\n  Post-Header : {postHeader} ({postHeader_mapped})"
+    },
+    {
+      "name": "WebVTT JSON Report",
+      "format": "json",
+      "template": "{ \"format\": \"WebVTT\", \"magic\": \"{magic}\", \"postHeaderByte\": {postHeader} }"
+    }
+  ],
+
+  "forensic": {
+    "category": "MediaSubtitle",
+    "riskLevel": "low",
+    "suspiciousPatterns": [
+      { "pattern": "EmbeddedCSS",          "description": "STYLE blocks can contain CSS that may be used for fingerprinting or overlay attacks in vulnerable player implementations." },
+      { "pattern": "MalformedTimestamps",   "description": "Non-monotonic or overlapping timestamps may indicate a corrupted or manually tampered file." }
+    ]
+  },
+
+  "aiHints": {
+    "analysisContext": "WebVTT is the W3C standard text-based caption format for HTML5 video. The 'WEBVTT' magic at offset 0 provides strong detection. The format supports cue settings (position, line, align, size, vertical), CSS styling via ::cue, REGION blocks for spatial layout, and NOTE blocks for comments.",
+    "suggestedInspections": [
+      "Verify the 'WEBVTT' header magic and check whether an optional description string follows on the header line.",
+      "Scan for STYLE blocks to identify embedded CSS rules that affect cue rendering via the ::cue pseudo-element.",
+      "Check for REGION definitions to determine if the file uses multi-region spatial subtitle positioning.",
+      "Validate cue timestamp ordering and detect any overlapping or out-of-order time ranges.",
+      "Look for voice tags (<v speaker>) to identify multi-speaker caption files used in accessibility workflows."
+    ]
+  },
+
+  "TechnicalDetails": {
+    "specification": "W3C WebVTT: The Web Video Text Tracks Format — https://www.w3.org/TR/webvtt1/",
+    "endianness": "N/A (text format)",
+    "encoding": "UTF-8 mandatory (per W3C spec); BOM permitted but not required",
+    "timestampFormat": "HH:MM:SS.mmm --> HH:MM:SS.mmm (period as decimal separator, unlike SRT which uses comma)",
+    "cueSettings": "position:X%, line:Y, align:start|center|end, size:X%, vertical:rl|lr",
+    "styling": "CSS ::cue pseudo-element; inline tags: <b>, <i>, <u>, <c.class>, <v speaker>, <lang>, <ruby>/<rt>",
+    "notes": "WebVTT is the recommended caption format for all modern web video. It supersedes SRT for web use cases and provides features comparable to TTML with simpler authoring."
+  },
+
+  "QualityMetrics": {
+    "CompletenessScore": 89,
+    "DocumentationLevel": "comprehensive",
+    "BlocksDefined": 4,
+    "ValidationRules": 3,
+    "LastUpdated": "2026-04-14",
+    "PriorityFormat": true,
+    "AutoRefined": false
+  }
+}

--- a/Sources/Core/WpfHexEditor.Core.Definitions/FormatDefinitions/System/ETL.whfmt
+++ b/Sources/Core/WpfHexEditor.Core.Definitions/FormatDefinitions/System/ETL.whfmt
@@ -1,0 +1,328 @@
+{
+  "diffMode": "binary",
+  "formatName": "Event Trace Log (ETW)",
+  "version": "1.0",
+  "extensions": [ ".etl" ],
+  "description": "Windows Event Tracing for Windows (ETW) log file produced by System.Diagnostics.Tracing, xperf, WPR, or the NT kernel logger; begins with one or more WMI_BUFFER_HEADER structures of 0x138 bytes each.",
+  "category": "System",
+  "author": "WPFHexaEditor Team",
+  "MimeTypes": [ "application/octet-stream", "application/x-etl" ],
+  "UseCases": [
+    "Windows performance profiling with WPR/xperf/PerfView",
+    "Kernel-mode event capture for scheduler, I/O, memory analysis",
+    ".NET runtime EventPipe tracing (pre-NetTrace format)",
+    "Security audit log capture via ETW providers",
+    "WPA (Windows Performance Analyzer) trace analysis"
+  ],
+  "software": [
+    { "name": "Windows Performance Recorder (WPR)", "role": "producer" },
+    { "name": "xperf / Windows Performance Toolkit",  "role": "producer/consumer" },
+    { "name": "PerfView",                             "role": "consumer" },
+    { "name": "Windows Performance Analyzer (WPA)",   "role": "consumer" },
+    { "name": "tracerpt.exe",                         "role": "consumer" }
+  ],
+  "formatRelationships": {
+    "relatedFormats": [ "NetTrace (.nettrace)", "WEL (.evtx)", "BLG Performance Counter Log" ],
+    "container": null,
+    "notes": "ETL files may be merged (tracerpt /merge) and can contain kernel + user-mode events in a single file. Large sessions produce multi-part .etl files."
+  },
+
+  "detection": {
+    "signatures": [
+      {
+        "value": "0000000000000000",
+        "offset": 0,
+        "label": "WMI_BUFFER_HEADER BufferSize placeholder — extension-primary detection",
+        "weight": 5,
+        "required": false
+      }
+    ],
+    "extensionSignatures": [
+      {
+        "extension": ".etl",
+        "label": "ETW Event Trace Log extension",
+        "weight": 70,
+        "required": true
+      }
+    ],
+    "matchMode": "weighted",
+    "MinimumScore": 60,
+    "Strength": "Weak",
+    "EntropyHint": {
+      "min": 4.0,
+      "max": 7.5,
+      "note": "Event payload entropy varies widely; compressed or encrypted providers push entropy toward 7.5."
+    },
+    "validation": {
+      "expression": "FILE_EXTENSION == '.etl'",
+      "description": "ETW files have no reliable byte-level magic; detection relies primarily on the .etl file extension and structural heuristics of the WMI_BUFFER_HEADER."
+    }
+  },
+
+  "variables": {
+    "bufferSize":       { "offset": 0,   "length": 4,  "type": "uint32le", "description": "WMI_BUFFER_HEADER.BufferSize — total size of this buffer in bytes" },
+    "savedOffset":      { "offset": 4,   "length": 4,  "type": "uint32le", "description": "WMI_BUFFER_HEADER.SavedOffset — offset to the last valid event in the buffer" },
+    "currentOffset":    { "offset": 8,   "length": 4,  "type": "uint32le", "description": "WMI_BUFFER_HEADER.CurrentOffset — current write position" },
+    "referenceCount":   { "offset": 12,  "length": 4,  "type": "int32le",  "description": "WMI_BUFFER_HEADER.ReferenceCount — active reference count" },
+    "timeStampLow":     { "offset": 16,  "length": 4,  "type": "uint32le", "description": "WMI_BUFFER_HEADER.TimeStamp low 32 bits (LARGE_INTEGER)" },
+    "timeStampHigh":    { "offset": 20,  "length": 4,  "type": "uint32le", "description": "WMI_BUFFER_HEADER.TimeStamp high 32 bits (LARGE_INTEGER)" },
+    "sequenceNumber":   { "offset": 24,  "length": 8,  "type": "uint64le", "description": "WMI_BUFFER_HEADER.SequenceNumber — monotonically increasing buffer sequence" },
+    "clockType":        { "offset": 32,  "length": 4,  "type": "uint32le", "description": "WMI_BUFFER_HEADER.Wnode.ClientContext — clock resolution (0=QueryPerformanceCounter, 1=SystemTime, 2=CpuCycles)" },
+    "bufferType":       { "offset": 36,  "length": 4,  "type": "uint32le", "description": "WMI_BUFFER_HEADER.BufferType — 0=generic, 1=rundown, 2=ctx switch, 3=flush" },
+    "loggerName":       { "offset": 292, "length": 64, "type": "utf16le",  "description": "WMI_BUFFER_HEADER.LoggerName — null-terminated wide string name of the ETW session" }
+  },
+
+  "blocks": [
+    {
+      "type": "signature",
+      "name": "WMI_BUFFER_HEADER (First Buffer)",
+      "offset": 0,
+      "length": 312,
+      "color": "#1565C0",
+      "opacity": 0.8,
+      "description": "First WMI_BUFFER_HEADER structure (0x138 = 312 bytes) at the start of the ETL file; contains session metadata, timing info, logger name, and buffer accounting fields used by the ETW runtime.",
+      "storeAs": "firstBufferHeader",
+      "valueType": "struct"
+    },
+    {
+      "type": "field",
+      "name": "BufferSize",
+      "offset": 0,
+      "length": 4,
+      "color": "#1976D2",
+      "opacity": 0.75,
+      "description": "Total size of this WMI buffer in bytes; typically 65536 (64 KB) or a multiple thereof; defines the boundary of the first buffer page in the ETL file.",
+      "storeAs": "bufferSize",
+      "valueType": "uint32",
+      "endianness": "little"
+    },
+    {
+      "type": "field",
+      "name": "SavedOffset",
+      "offset": 4,
+      "length": 4,
+      "color": "#42A5F5",
+      "opacity": 0.65,
+      "description": "Offset within this buffer to the last fully written event record; used during flush to determine valid data boundaries when the buffer is only partially filled.",
+      "storeAs": "savedOffset",
+      "valueType": "uint32",
+      "endianness": "little"
+    },
+    {
+      "type": "field",
+      "name": "CurrentOffset",
+      "offset": 8,
+      "length": 4,
+      "color": "#42A5F5",
+      "opacity": 0.60,
+      "description": "Current write offset within the buffer at the time of capture; events between SavedOffset and CurrentOffset may be incomplete if the session was terminated abnormally.",
+      "storeAs": "currentOffset",
+      "valueType": "uint32",
+      "endianness": "little"
+    },
+    {
+      "type": "field",
+      "name": "Timestamp (LARGE_INTEGER)",
+      "offset": 16,
+      "length": 8,
+      "color": "#26C6DA",
+      "opacity": 0.7,
+      "description": "Buffer creation timestamp as a Windows LARGE_INTEGER (100-nanosecond intervals since January 1, 1601 UTC); determines the absolute time base for events in this buffer.",
+      "storeAs": "timestamp",
+      "valueType": "filetime",
+      "endianness": "little"
+    },
+    {
+      "type": "field",
+      "name": "SequenceNumber",
+      "offset": 24,
+      "length": 8,
+      "color": "#AB47BC",
+      "opacity": 0.65,
+      "description": "Monotonically increasing 64-bit sequence number assigned by the ETW runtime; gaps in sequence numbers across buffers indicate dropped events.",
+      "storeAs": "sequenceNumber",
+      "valueType": "uint64",
+      "endianness": "little"
+    },
+    {
+      "type": "field",
+      "name": "ClockType (ClientContext)",
+      "offset": 32,
+      "length": 4,
+      "color": "#FFA726",
+      "opacity": 0.7,
+      "description": "Clock resolution used for event timestamps in this session; affects timestamp accuracy and overhead during collection.",
+      "storeAs": "clockType",
+      "valueType": "uint32",
+      "endianness": "little",
+      "valueMap": {
+        "0": "QueryPerformanceCounter (highest resolution, ~100ns)",
+        "1": "SystemTime (low resolution, ~15ms)",
+        "2": "CPU cycle counter (very high resolution, skewed by frequency scaling)"
+      }
+    },
+    {
+      "type": "field",
+      "name": "BufferType",
+      "offset": 36,
+      "length": 4,
+      "color": "#EF5350",
+      "opacity": 0.65,
+      "description": "Indicates the purpose of this buffer within the ETW session; distinguishes normal event buffers from rundown, context-switch, or flush buffers.",
+      "storeAs": "bufferType",
+      "valueType": "uint32",
+      "endianness": "little",
+      "valueMap": {
+        "0": "Generic event buffer",
+        "1": "Rundown buffer (session start/stop metadata)",
+        "2": "Context-switch buffer",
+        "3": "Flush buffer"
+      }
+    },
+    {
+      "type": "field",
+      "name": "LoggerName",
+      "offset": 292,
+      "length": 64,
+      "color": "#66BB6A",
+      "opacity": 0.75,
+      "description": "Null-terminated UTF-16LE string holding the ETW session name, e.g. 'NT Kernel Logger', 'EventLog-System', or a custom provider session name up to 31 characters.",
+      "storeAs": "loggerName",
+      "valueType": "utf16string",
+      "endianness": "little"
+    },
+    {
+      "type": "repeating",
+      "name": "ETW Event Records",
+      "offset": 312,
+      "length": "variable",
+      "color": "#78909C",
+      "opacity": 0.5,
+      "description": "Variable-length array of EVENT_RECORD structures following the WMI_BUFFER_HEADER; each record has an EVENT_HEADER (80 bytes) followed by provider-specific UserData payload."
+    },
+    {
+      "type": "metadata",
+      "name": "Subsequent Buffer Pages",
+      "offset": "bufferSize",
+      "length": "variable",
+      "color": "#546E7A",
+      "opacity": 0.45,
+      "description": "Additional WMI_BUFFER_HEADER + event record pages appended sequentially; each page is bufferSize bytes and follows immediately after the previous page."
+    }
+  ],
+
+  "assertions": [
+    {
+      "name": "BufferSizeReasonable",
+      "expression": "UINT32_LE(0) >= 4096 && UINT32_LE(0) <= 16777216",
+      "severity": "warning",
+      "message": "BufferSize is outside the expected range of 4 KB – 16 MB; typical ETW buffers are 64 KB. File may be corrupt or truncated."
+    },
+    {
+      "name": "SavedOffsetWithinBuffer",
+      "expression": "UINT32_LE(4) <= UINT32_LE(0)",
+      "severity": "error",
+      "message": "SavedOffset exceeds BufferSize; this indicates file truncation or memory corruption in the ETW buffer header."
+    },
+    {
+      "name": "CurrentOffsetWithinBuffer",
+      "expression": "UINT32_LE(8) <= UINT32_LE(0)",
+      "severity": "error",
+      "message": "CurrentOffset exceeds BufferSize; the buffer write pointer is past the buffer boundary, indicating a corrupt or truncated ETL file."
+    },
+    {
+      "name": "ValidClockType",
+      "expression": "UINT32_LE(32) <= 2",
+      "severity": "warning",
+      "message": "ClockType (ClientContext) is not a recognized value (0=QPC, 1=SystemTime, 2=CpuCycles); timestamp interpretation may be incorrect."
+    },
+    {
+      "name": "ValidBufferType",
+      "expression": "UINT32_LE(36) <= 3",
+      "severity": "info",
+      "message": "BufferType value is outside the known range (0-3); unknown buffer types may indicate a newer ETW format version."
+    }
+  ],
+
+  "navigation": {
+    "bookmarks": [
+      { "name": "WMI_BUFFER_HEADER[0]", "offset": 0,   "description": "First ETW buffer header — session metadata and timing" },
+      { "name": "Timestamp",            "offset": 16,  "description": "Buffer FILETIME timestamp (100-ns intervals since 1601-01-01)" },
+      { "name": "LoggerName",           "offset": 292, "description": "ETW session name as UTF-16LE string" },
+      { "name": "First Event Record",   "offset": 312, "description": "First EVENT_RECORD following the buffer header" }
+    ]
+  },
+
+  "inspector": {
+    "badge": "ETL",
+    "primaryField": "loggerName",
+    "showQualityScore": true,
+    "groups": [
+      {
+        "name": "Buffer Metadata",
+        "fields": [ "bufferSize", "savedOffset", "currentOffset", "referenceCount" ]
+      },
+      {
+        "name": "Timing",
+        "fields": [ "timeStampLow", "timeStampHigh", "sequenceNumber", "clockType" ]
+      },
+      {
+        "name": "Session",
+        "fields": [ "bufferType", "loggerName" ]
+      }
+    ]
+  },
+
+  "exportTemplates": [
+    {
+      "name": "ETL Buffer Summary",
+      "format": "text",
+      "template": "ETW Event Trace Log\n  Session      : {loggerName}\n  Buffer Size  : {bufferSize} bytes\n  Saved Offset : {savedOffset}\n  Clock Type   : {clockType}\n  Sequence #   : {sequenceNumber}"
+    },
+    {
+      "name": "ETL JSON Report",
+      "format": "json",
+      "template": "{ \"format\": \"ETL\", \"loggerName\": \"{loggerName}\", \"bufferSize\": {bufferSize}, \"clockType\": {clockType}, \"sequenceNumber\": {sequenceNumber} }"
+    }
+  ],
+
+  "forensic": {
+    "category": "SystemTelemetry",
+    "riskLevel": "medium",
+    "suspiciousPatterns": [
+      { "pattern": "KernelLoggerSession",       "description": "NT Kernel Logger sessions capture full process/thread/image-load events; may expose system-wide activity." },
+      { "pattern": "DroppedEvents",             "description": "Gaps in SequenceNumber across buffers indicate dropped events, possibly due to high-frequency malware activity." },
+      { "pattern": "UnknownProviderGUID",       "description": "Event records from unknown provider GUIDs may indicate undocumented or malicious ETW instrumentation." },
+      { "pattern": "TruncatedBuffer",           "description": "CurrentOffset > SavedOffset gap may indicate abnormal session termination; events between may be incomplete." }
+    ]
+  },
+
+  "aiHints": {
+    "analysisContext": "ETW ETL files contain kernel and user-mode event traces with nanosecond-resolution timestamps. They encode process lifecycle, thread scheduling, disk I/O, network activity, and custom provider events. Each buffer page is independently parseable. Dropped events are detectable via sequence number gaps.",
+    "suggestedInspections": [
+      "Check SequenceNumber continuity across buffer pages to detect dropped events or session gaps.",
+      "Identify the LoggerName to determine whether this is a kernel (NT Kernel Logger), security, or application-specific trace.",
+      "Correlate ClockType with event timestamps — CPU cycle counters are skewed on multi-core systems without frequency normalization.",
+      "Look for EventHeader.ProviderId GUIDs matching known security-sensitive providers (e.g., Microsoft-Windows-Security-Auditing).",
+      "Cross-reference process creation events (ProcessStart) with network connection events to build process-to-connection timelines."
+    ]
+  },
+
+  "TechnicalDetails": {
+    "specification": "Windows ETW internals — WMI_BUFFER_HEADER undocumented structure; EVENT_RECORD documented in evntcons.h (Windows SDK); ETL format partially documented in PerfView source (github.com/microsoft/perfview)",
+    "endianness": "little-endian (Windows native)",
+    "headerSize": "0x138 (312) bytes per WMI_BUFFER_HEADER",
+    "typicalBufferSize": "65536 bytes (64 KB) default; configurable via StartTrace BufferSize parameter",
+    "notes": "No standardized file magic; detection is extension-based. The first 4 bytes (BufferSize) are a plausible heuristic (65536 = 0x00010000) but not reliable across all configurations."
+  },
+
+  "QualityMetrics": {
+    "CompletenessScore": 88,
+    "DocumentationLevel": "comprehensive",
+    "BlocksDefined": 10,
+    "ValidationRules": 5,
+    "LastUpdated": "2026-04-14",
+    "PriorityFormat": false,
+    "AutoRefined": false
+  }
+}

--- a/Sources/Core/WpfHexEditor.Core.Definitions/WpfHexEditor.Core.Definitions.csproj
+++ b/Sources/Core/WpfHexEditor.Core.Definitions/WpfHexEditor.Core.Definitions.csproj
@@ -18,9 +18,9 @@
     <EmbeddedResource Include="FormatDefinitions\**\*.grammar" />
   </ItemGroup>
 
-  <!-- JSON Schema files distributed alongside the assembly -->
+  <!-- JSON Schema files embedded in the assembly (accessible via GetManifestResourceStream) -->
   <ItemGroup>
-    <None Include="*.schema.json" CopyToOutputDirectory="PreserveNewest" />
+    <EmbeddedResource Include="*.schema.json" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Sources/Editors/WpfHexEditor.Editor.CodeEditor/CodeEditorFactory.cs
+++ b/Sources/Editors/WpfHexEditor.Editor.CodeEditor/CodeEditorFactory.cs
@@ -35,7 +35,7 @@ public sealed class CodeEditorFactory : IEditorFactory
     public bool CanOpen(string filePath)
     {
         var ext = Path.GetExtension(filePath)?.ToLowerInvariant();
-        if (ext is ".json" or ".whfmt" or ".whjson" or ".whlang") return true;
+        if (ext is ".json" or ".whjson" or ".whlang") return true;
 
         // EditorHint fast-path: language definition carries the preferred editor hint
         // populated from the parent .whfmt "preferredEditor" field.  O(1) after registry warmup.
@@ -172,5 +172,5 @@ file sealed class CodeEditorDescriptor : IEditorDescriptor
     public string Id          => "code-editor";
     public string DisplayName => "Code Editor";
     public string Description => "Multi-language code editor (JSON, .whlang, and any registered language)";
-    public IReadOnlyList<string> SupportedExtensions => [".json", ".whfmt", ".whjson", ".whlang"];
+    public IReadOnlyList<string> SupportedExtensions => [".json", ".whjson", ".whlang"];
 }

--- a/Sources/Editors/WpfHexEditor.Editor.Core/ValidationError.cs
+++ b/Sources/Editors/WpfHexEditor.Editor.Core/ValidationError.cs
@@ -2,64 +2,73 @@
 // GNU Affero General Public License v3.0 - 2026
 // Author : Derek Tremblay (derektremblay666@gmail.com)
 // Contributors: Claude Sonnet 4.6
-// Project: WpfHexEditor.Editor.CodeEditor
-// File: Models/ValidationError.cs
-// Description: Validation error model for the CodeEditor assembly.
-//              WpfHexEditor.Editor.Core defines its own canonical
-//              ValidationError / ValidationSeverity / ValidationLayer.
-//              The two sets share identical ordinals so that cross-assembly
-//              int casts are safe.
+// Project: WpfHexEditor.Editor.Core
+// File: ValidationError.cs
+// Description: Validation error model shared across all editor modules.
+//              Moved from WpfHexEditor.Editor.CodeEditor.Models so that
+//              StructureEditor (and future editors) can reference it without
+//              taking a dependency on the CodeEditor assembly.
 //////////////////////////////////////////////
 
-namespace WpfHexEditor.Editor.CodeEditor.Models;
+namespace WpfHexEditor.Editor.Core.Validation;
 
 /// <summary>Severity level of a validation diagnostic.</summary>
 public enum ValidationSeverity
 {
-    /// <summary>Informational — no action required.</summary>
-    Info    = 0,
-    /// <summary>Non-critical issue.</summary>
-    Warning = 1,
-    /// <summary>Critical error.</summary>
-    Error   = 2,
+    /// <summary>Informational message — no action required.</summary>
+    Info,
+    /// <summary>Non-critical issue that should be reviewed.</summary>
+    Warning,
+    /// <summary>Critical error that prevents the format from working.</summary>
+    Error,
 }
 
 /// <summary>Validation layer that detected the diagnostic.</summary>
 public enum ValidationLayer
 {
-    /// <summary>Layer 1: JSON syntax.</summary>
-    JsonSyntax  = 0,
-    /// <summary>Layer 2: Schema compliance.</summary>
-    Schema      = 1,
-    /// <summary>Layer 3: Format-specific rules.</summary>
-    FormatRules = 2,
-    /// <summary>Layer 4: Semantic errors.</summary>
-    Semantic    = 3,
-    /// <summary>Layer 5: External Language Server diagnostics.</summary>
-    Lsp         = 4,
+    /// <summary>Layer 1: JSON syntax errors.</summary>
+    JsonSyntax,
+    /// <summary>Layer 2: Missing required properties (schema compliance).</summary>
+    Schema,
+    /// <summary>Layer 3: Format-specific rule violations.</summary>
+    FormatRules,
+    /// <summary>Layer 4: Semantic errors (invalid references, etc.).</summary>
+    Semantic,
+    /// <summary>Layer 5: Diagnostics from an external Language Server.</summary>
+    Lsp,
 }
 
 /// <summary>
 /// A single validation diagnostic with source location and severity.
-/// Produced by <c>FormatSchemaValidator</c> and LSP integration.
+/// Produced by <c>FormatSchemaValidator</c> and any LSP integration.
 /// </summary>
 public class ValidationError
 {
     /// <summary>Line number where the error occurs (0-based).</summary>
     public int Line { get; set; }
+
     /// <summary>Column where the error starts (0-based).</summary>
     public int Column { get; set; }
-    /// <summary>Length of the error span (for underlining).</summary>
+
+    /// <summary>Length of the error span (used for underlining).</summary>
     public int Length { get; set; }
+
     /// <summary>Human-readable error message.</summary>
     public string Message { get; set; } = string.Empty;
-    /// <summary>Severity level.</summary>
+
+    /// <summary>Severity level of this diagnostic.</summary>
     public ValidationSeverity Severity { get; set; }
-    /// <summary>Optional error code.</summary>
+
+    /// <summary>Optional error code for categorisation.</summary>
     public string ErrorCode { get; set; } = string.Empty;
+
     /// <summary>Validation layer that produced this diagnostic.</summary>
     public ValidationLayer Layer { get; set; }
-    /// <summary>Sub-system that produced this error (e.g. "lsp", "schema").</summary>
+
+    /// <summary>
+    /// Identifies the sub-system that produced this error (e.g. "lsp", "schema").
+    /// Used to selectively replace error sets on incremental updates.
+    /// </summary>
     public string? Source { get; set; }
 
     /// <summary>Initialises a diagnostic with default Error severity.</summary>

--- a/Sources/Editors/WpfHexEditor.Editor.MarkdownEditor/Controls/MarkdownEditorHost.xaml.cs
+++ b/Sources/Editors/WpfHexEditor.Editor.MarkdownEditor/Controls/MarkdownEditorHost.xaml.cs
@@ -681,9 +681,10 @@ public sealed partial class MarkdownEditorHost : UserControl,
                 break;
         }
 
-        // Force the WebView2 HWND to match the new layout slot via SetWindowPos.
-        // WPF arrange passes do not propagate to Win32 children after grid rebuilds.
+        // Force child controls to match the new layout slot — WPF arrange passes
+        // do not propagate reliably to Win32 children or custom viewports after grid rebuilds.
         _preview.InvalidateWebViewSize();
+        _editor.InvalidateViewportSize();
     }
 
     private void BuildHorizontalLayout(bool editorFirst,

--- a/Sources/Editors/WpfHexEditor.Editor.MarkdownEditor/Controls/MarkdownPreviewPane.xaml
+++ b/Sources/Editors/WpfHexEditor.Editor.MarkdownEditor/Controls/MarkdownPreviewPane.xaml
@@ -26,9 +26,12 @@
          item can be updated dynamically when fullscreen state changes. -->
 
     <Grid>
-        <!-- WebView2 (WinForms) inside WindowsFormsHost — Stretch ensures the HWND fills its Grid cell -->
+        <!-- WebView2 (WinForms) inside WindowsFormsHost — Stretch ensures the HWND fills its Grid cell.
+             Margin="1" keeps the HWND 1 px away from the panel edge so the docking selection
+             border (drawn in WPF below the HWND) is not occluded by the Win32 airspace surface. -->
         <WindowsFormsHost x:Name="_webViewHost"
                           Visibility="Collapsed"
+                          Margin="2"
                           HorizontalAlignment="Stretch"
                           VerticalAlignment="Stretch" />
 

--- a/Sources/Editors/WpfHexEditor.Editor.MarkdownEditor/Controls/MarkdownPreviewPane.xaml.cs
+++ b/Sources/Editors/WpfHexEditor.Editor.MarkdownEditor/Controls/MarkdownPreviewPane.xaml.cs
@@ -136,8 +136,11 @@ public sealed partial class MarkdownPreviewPane : UserControl
         var scaleX = source?.CompositionTarget?.TransformToDevice.M11 ?? 1.0;
         var scaleY = source?.CompositionTarget?.TransformToDevice.M22 ?? 1.0;
 
-        var w = (int)Math.Max(width  * scaleX, 1);
-        var h = (int)Math.Max(height * scaleY, 1);
+        // Subtract the 1 px Margin on each side (2 px per axis) so the HWND does not
+        // occlude the WPF docking selection border rendered beneath the WindowsFormsHost.
+        const double MarginLogical = 2.0;
+        var w = (int)Math.Max((width  - MarginLogical * 2) * scaleX, 1);
+        var h = (int)Math.Max((height - MarginLogical * 2) * scaleY, 1);
 
         // Resize WindowsFormsHost HWND, then walk the entire child chain:
         // WindowsFormsHost → WinForms container → WebView2 WinForms → browser child HWNDs
@@ -326,6 +329,10 @@ public sealed partial class MarkdownPreviewPane : UserControl
             // Show WebView2 host, hide loading overlay
             _webViewHost.Visibility    = Visibility.Visible;
             _loadingOverlay.Visibility = Visibility.Collapsed;
+
+            // Force Win32 HWND tree to match the current WPF slot — SizeChanged will not
+            // fire again if the control is already at its final size when init completes.
+            InvalidateWebViewSize();
 
             // Render any content that arrived before initialization completed
             if (!string.IsNullOrEmpty(_pendingMarkdown))

--- a/Sources/Editors/WpfHexEditor.Editor.StructureEditor/Controls/SeverityToBrushConverter.cs
+++ b/Sources/Editors/WpfHexEditor.Editor.StructureEditor/Controls/SeverityToBrushConverter.cs
@@ -10,7 +10,7 @@
 using System.Globalization;
 using System.Windows.Data;
 using System.Windows.Media;
-using WpfHexEditor.Editor.StructureEditor.ViewModels;
+using WpfHexEditor.Editor.Core.Validation;
 
 namespace WpfHexEditor.Editor.StructureEditor.Controls;
 

--- a/Sources/Editors/WpfHexEditor.Editor.StructureEditor/Controls/StructureEditor.xaml.cs
+++ b/Sources/Editors/WpfHexEditor.Editor.StructureEditor/Controls/StructureEditor.xaml.cs
@@ -12,7 +12,9 @@ using System.IO;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
+using WpfHexEditor.Editor.CodeEditor.Services;
 using WpfHexEditor.Editor.Core;
+using WpfHexEditor.Editor.Core.Validation;
 using WpfHexEditor.Editor.StructureEditor.ViewModels;
 
 namespace WpfHexEditor.Editor.StructureEditor.Controls;
@@ -26,6 +28,7 @@ public sealed partial class StructureEditor : UserControl, IDocumentEditor, IOpe
     // ── State ─────────────────────────────────────────────────────────────────
 
     private readonly StructureEditorViewModel _vm = new();
+    private readonly FormatSchemaValidator    _schemaValidator = new();
     private string _filePath = string.Empty;
 
     // ── Constructor ───────────────────────────────────────────────────────────
@@ -42,6 +45,20 @@ public sealed partial class StructureEditor : UserControl, IDocumentEditor, IOpe
         PasteCommand     = new ViewModels.RelayCommand(() => { }, () => false);
         DeleteCommand    = new ViewModels.RelayCommand(() => { }, () => false);
         SelectAllCommand = new ViewModels.RelayCommand(() => { }, () => false);
+
+        // Wire FormatSchemaValidator (4-layer: JSON syntax, schema, rules, semantic)
+        _vm.SetValidator(async json =>
+        {
+            var errors = await Task.Run(() => _schemaValidator.Validate(json));
+            return errors.Select(e => new ValidationSummaryItem
+            {
+                Severity = (ValidationSeverity)(int)e.Severity,
+                Message  = e.Message,
+                Line     = e.Line,
+                Column   = e.Column,
+                Layer    = e.Layer.ToString(),
+            }).ToList();
+        });
 
         // Bind child tabs through DataContext
         MetadataTabCtrl.DataContext  = _vm.Metadata;

--- a/Sources/Editors/WpfHexEditor.Editor.StructureEditor/ViewModels/StructureEditorViewModel.cs
+++ b/Sources/Editors/WpfHexEditor.Editor.StructureEditor/ViewModels/StructureEditorViewModel.cs
@@ -15,6 +15,8 @@ using System.Text.Json.Serialization;
 using System.Windows.Threading;
 using WpfHexEditor.Core.FormatDetection;
 using WpfHexEditor.Core.ViewModels;
+using WpfHexEditor.Editor.Core;
+using WpfHexEditor.Editor.Core.Validation;
 
 namespace WpfHexEditor.Editor.StructureEditor.ViewModels;
 

--- a/Sources/Editors/WpfHexEditor.Editor.StructureEditor/ViewModels/ValidationSummaryItem.cs
+++ b/Sources/Editors/WpfHexEditor.Editor.StructureEditor/ViewModels/ValidationSummaryItem.cs
@@ -8,18 +8,22 @@
 // Description: Model for a single row in the ValidationBar.
 //////////////////////////////////////////////
 
-namespace WpfHexEditor.Editor.StructureEditor.ViewModels;
+using WpfHexEditor.Editor.Core.Validation;
 
-/// <summary>Severity level for a validation result.</summary>
-public enum ValidationSeverity { Info, Warning, Error }
+namespace WpfHexEditor.Editor.StructureEditor.ViewModels;
 
 /// <summary>A single row displayed in the inline <c>ValidationBar</c>.</summary>
 public sealed class ValidationSummaryItem
 {
+    /// <summary>Severity level of this validation result.</summary>
     public ValidationSeverity Severity { get; init; }
+    /// <summary>Human-readable description of the issue.</summary>
     public string             Message  { get; init; } = "";
+    /// <summary>Line where the issue starts (0-based).</summary>
     public int                Line     { get; init; }
+    /// <summary>Column where the issue starts (0-based).</summary>
     public int                Column   { get; init; }
+    /// <summary>Validation layer that produced this item (e.g. Schema, Semantic).</summary>
     public string             Layer    { get; init; } = "";
 
     /// <summary>Segoe MDL2 glyph for the severity icon.</summary>

--- a/Sources/Editors/WpfHexEditor.Editor.TextEditor/Controls/TextEditor.xaml
+++ b/Sources/Editors/WpfHexEditor.Editor.TextEditor/Controls/TextEditor.xaml
@@ -27,10 +27,12 @@
                       Focusable="False"
                       Background="{DynamicResource TE_Background}"
                       ScrollChanged="ScrollView_ScrollChanged">
-            <Grid>
-                <!-- Minimum width so horizontal scrollbar appears -->
+            <Grid x:Name="ViewportGrid">
+                <!-- Auto column for no-wrap (content drives horizontal extent).
+                     Switched to * in code-behind when word wrap is on so MeasureOverride
+                     receives a finite available width instead of infinity. -->
                 <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition x:Name="ViewportGridColumn" Width="Auto"/>
                 </Grid.ColumnDefinitions>
                 <local:TextViewport x:Name="Viewport"
                                     HorizontalAlignment="Stretch"

--- a/Sources/Editors/WpfHexEditor.Editor.TextEditor/Controls/TextEditor.xaml.cs
+++ b/Sources/Editors/WpfHexEditor.Editor.TextEditor/Controls/TextEditor.xaml.cs
@@ -100,6 +100,9 @@ public sealed partial class TextEditor : UserControl, IDocumentEditor, IBufferAw
     {
         InitializeComponent();
 
+        ScrollView.Loaded      += (_, _) => InvalidateViewportSize();
+        ScrollView.SizeChanged += (_, _) => InvalidateViewportSize();
+
         // Wire ViewModel
         Viewport.Attach(_vm);
         _vm.PropertyChanged += OnVmPropertyChanged;
@@ -336,7 +339,30 @@ public sealed partial class TextEditor : UserControl, IDocumentEditor, IBufferAw
             ScrollView.HorizontalScrollBarVisibility = value
                 ? ScrollBarVisibility.Disabled
                 : ScrollBarVisibility.Auto;
+            // Star column: ScrollViewer passes finite viewport width to MeasureOverride.
+            // Auto column: content drives horizontal extent (required for horizontal scroll).
+            ViewportGridColumn.Width = value
+                ? new GridLength(1, GridUnitType.Star)
+                : GridLength.Auto;
         }
+    }
+
+    /// <summary>
+    /// Deferred viewport sync — schedules a layout-priority callback that reads
+    /// the ScrollViewer's finalized ViewportWidth/Height and resizes the rendering surface.
+    /// Call after any external layout change (grid rebuild, splitter drag, initial open).
+    /// </summary>
+    public void InvalidateViewportSize()
+    {
+        Dispatcher.BeginInvoke(System.Windows.Threading.DispatcherPriority.Loaded, () =>
+        {
+            if (Viewport.LineHeight <= 0) return;
+            ViewportGrid.MinWidth = ScrollView.ViewportWidth;
+            if (!Viewport.IsWordWrapEnabled)
+                Viewport.Width = Math.Max(Viewport.EstimatedMaxWidth, ScrollView.ViewportWidth);
+            Viewport.Height = Math.Max(Viewport.TotalHeight + Viewport.LineHeight, ScrollView.ViewportHeight);
+            Viewport.InvalidateVisual();
+        });
     }
 
     // -----------------------------------------------------------------------
@@ -419,12 +445,7 @@ public sealed partial class TextEditor : UserControl, IDocumentEditor, IBufferAw
     }
 
     /// <inheritdoc/>
-    public void Save()
-    {
-        if (string.IsNullOrEmpty(_vm.FilePath)) return;
-        _vm.SaveFileAsync(_vm.FilePath).GetAwaiter().GetResult();
-        StatusMessage?.Invoke(this, $"Saved: {Path.GetFileName(_vm.FilePath)}");
-    }
+    public void Save() => _ = SaveAsync();
 
     /// <inheritdoc/>
     public async Task SaveAsync(CancellationToken ct = default)
@@ -879,11 +900,15 @@ public sealed partial class TextEditor : UserControl, IDocumentEditor, IBufferAw
         Viewport.FirstVisibleLine   = firstLine;
         Viewport.HorizontalOffset   = e.HorizontalOffset;
 
-        // Adjust the viewport dimensions to fill the scroll area.
-        // Word wrap: clamp width to viewport (no horizontal extent needed).
-        Viewport.Width  = Viewport.IsWordWrapEnabled
-            ? ScrollView.ViewportWidth
-            : Math.Max(Viewport.EstimatedMaxWidth, ScrollView.ViewportWidth);
+        // Keep the inner grid at least as wide as the visible viewport so the
+        // background fills the full pane after a resize (avoids empty strip on the right).
+        ViewportGrid.MinWidth = ScrollView.ViewportWidth;
+
+        // Word wrap: column is Width="*" so WPF passes the correct finite viewport width
+        // through MeasureOverride automatically — no explicit Width needed.
+        // No-wrap: explicit Width provides the horizontal scroll extent.
+        if (!Viewport.IsWordWrapEnabled)
+            Viewport.Width = Math.Max(Viewport.EstimatedMaxWidth, ScrollView.ViewportWidth);
         Viewport.Height = Math.Max(Viewport.TotalHeight + Viewport.LineHeight, ScrollView.ViewportHeight);
 
         ViewportScrollChanged?.Invoke(this, e);

--- a/docs/WHFMT_LOADING_PIPELINE.md
+++ b/docs/WHFMT_LOADING_PIPELINE.md
@@ -1,0 +1,443 @@
+﻿# WHFMT Loading Pipeline
+
+> **Scope:** End-to-end lifecycle of a `.whfmt` format definition — from embedded resource to
+> in-memory `FormatDefinition` and format detection.  
+> **Last updated:** 2026-04-14
+
+---
+
+## 1. What is a `.whfmt` file?
+
+A `.whfmt` file is a **JSONC document** (JSON + comments + trailing commas) that describes a
+binary or text file format. It contains:
+
+| Section | Purpose |
+|---|---|
+| `formatName`, `version`, `category` | Identity metadata |
+| `extensions` | Associated file extensions |
+| `detection` | Signature rules, entropy hints, text patterns |
+| `blocks` | Binary structure layout (optional for text formats) |
+| `variables` / `functions` | Script state & custom helpers |
+| `VersionDetection`, `VersionedBlocks` | Per-version structure variants |
+| `Checksums`, `Assertions` | Integrity & well-formedness constraints |
+| `Forensic`, `Navigation`, `Inspector` | Analysis, UX, and tooling metadata |
+| `preferredEditor`, `diffMode` | Editor routing hints |
+
+**Validation rules (`IsValid()`):**
+- `FormatName` must be non-empty.
+- `Detection` must be non-null and internally valid.
+- Binary formats (`isTextFormat = false`) **must** declare at least one `Block`.
+- Text formats may have zero blocks (identified by extension/signature only).
+
+---
+
+## 2. File Organisation
+
+```
+Sources/
+└── Core/
+    └── WpfHexEditor.Core.Definitions/
+        ├── FormatDefinitions/          ← whfmt files (embedded resources)
+        │   ├── Archives/
+        │   ├── Database/
+        │   ├── Images/
+        │   ├── Programming/
+        │   └── ...
+        └── WpfHexEditor.Core.Definitions.csproj
+```
+
+All `.whfmt` (and `.grammar`) files under `FormatDefinitions/` are compiled as **manifest
+embedded resources** via:
+
+```xml
+<ItemGroup>
+  <EmbeddedResource Include="FormatDefinitions\**\*.whfmt" />
+  <EmbeddedResource Include="FormatDefinitions\**\*.grammar" />
+</ItemGroup>
+```
+
+Resulting resource key pattern:
+```
+WpfHexEditor.Definitions.FormatDefinitions.{Category}.{FormatName}.whfmt
+```
+
+---
+
+## 3. Complete Loading Pipeline
+
+### 3.1 High-Level Overview
+
+```mermaid
+flowchart TD
+    A([App Startup]) --> B[MainWindow\nInitializePluginSystemAsync]
+    B --> C[FormatCatalogService\nInitialize]
+
+    C --> D[EmbeddedFormatCatalog\nGetAll]
+    C --> E[External directory\n*.whfmt on disk]
+    C --> F[User AppData\n%APPDATA%\\WpfHexEditor\\FormatDefinitions]
+
+    D --> G[MakeEntries\nScan manifest resources]
+    G --> H[LoadHeader / LoadGrammarHeader\nLightweight JSON/XML parse]
+    H --> I[(EmbeddedFormatEntry\nFrozenSet — headers only)]
+
+    I --> J[GetJson\nFull JSON — cached]
+    E --> J
+    F --> J
+
+    J --> K[ImportFromJson\nDeserialize + JSONC guard]
+    K --> L{IsValid?}
+    L -- Yes --> M[(FormatDefinition\nin memory)]
+    L -- No --> N[FormatLoadFailure\nrecorded]
+
+    M --> O[FormatDetectionService\nSetSharedCatalog]
+    O --> P([CatalogReady event\nIDE ready])
+```
+
+---
+
+### 3.2 Step-by-step Breakdown
+
+#### Step 1 — Header Scan (`EmbeddedFormatCatalog.MakeEntries`)
+
+Triggered **once** (lazy) on first call to `GetAll()`.
+
+```mermaid
+sequenceDiagram
+    participant App as App (MainWindow)
+    participant Cat as EmbeddedFormatCatalog (Singleton)
+    participant Asm as Assembly
+
+    App->>Cat: GetAll()
+    Cat->>Cat: LazyInitializer.EnsureInitialized
+    Cat->>Asm: GetManifestResourceNames()
+    Asm-->>Cat: string[] resourceKeys
+
+    loop Each key containing "FormatDefinitions"
+        alt ends with .whfmt
+            Cat->>Asm: GetManifestResourceStream(key)
+            Asm-->>Cat: Stream
+            Cat->>Cat: LoadHeader(key)\nJsonDocument.Parse — skip comments
+            Cat-->>Cat: EmbeddedFormatEntry (lightweight)
+        else ends with .grammar
+            Cat->>Asm: GetManifestResourceStream(key)
+            Cat->>Cat: LoadGrammarHeader(key)\nXmlReader — name + extensions
+            Cat-->>Cat: EmbeddedFormatEntry
+        end
+    end
+
+    Cat-->>App: IReadOnlySet<EmbeddedFormatEntry> (FrozenSet, sorted)
+```
+
+**`EmbeddedFormatEntry` fields loaded at this stage:**
+
+| Field | Source JSON path |
+|---|---|
+| `Name` | `formatName` |
+| `Category` | Extracted from resource key path |
+| `Description` | `description` |
+| `Extensions` | `extensions[]` |
+| `Version` | `version` |
+| `Author` | `author` |
+| `QualityScore` | `QualityMetrics.CompletenessScore` |
+| `PreferredEditor` | `preferredEditor` |
+| `IsTextFormat` | `detection.isTextFormat` |
+| `HasSyntaxDefinition` | presence of `syntaxDefinition` key |
+| `DiffMode` | `diffMode` |
+
+> Block definitions, variables, and functions are **NOT** loaded at this stage.
+
+---
+
+#### Step 2 — JSON Cache (`EmbeddedFormatCatalog.GetJson`)
+
+```mermaid
+flowchart LR
+    A[GetJson\nresourceKey] --> B{_jsonCache\nhit?}
+    B -- Yes --> C[Return cached string]
+    B -- No --> D[Lock _jsonCacheLock]
+    D --> E{Double-check\ncache}
+    E -- Still missing --> F[OpenManifestResourceStream\nReadToEnd]
+    F --> G[Store in _jsonCache]
+    G --> C
+    E -- Now present --> C
+```
+
+- Cache scope: **process lifetime** (assembly resources are immutable).
+- Thread-safe: double-check locking pattern.
+- `PreWarm()` can eagerly fill the cache at startup.
+
+---
+
+#### Step 3 — Deserialization & Validation (`FormatDetectionService.ImportFromJson`)
+
+```mermaid
+flowchart TD
+    A[ImportFromJson\njson string] --> B[TrimStart span]
+    B --> C{Starts with\n'/*' or '//'?}
+    C -- Yes --> D[Skip comment block\nadvance pointer]
+    D --> C
+    C -- No --> E{"First char\n'{' or '['?"}
+    E -- No --> F[Return null\nnot JSON]
+    E -- Yes --> G[JsonSerializer.Deserialize\nFormatDefinition\nPropertyNameCaseInsensitive\nSkipComments\nAllowTrailingCommas]
+    G --> H{IsValid?}
+    H -- Yes --> I[Return FormatDefinition]
+    H -- No --> J[Return null]
+```
+
+> The JSONC comment-skip guard (Step C→D) is critical: many `.whfmt` files begin with a
+> `/* header block */`. Without it, the `{` check fails and the entire format is silently
+> discarded. See memory: `feedback_whfmt_guard.md`.
+
+---
+
+#### Step 4 — Multi-Source Catalog Assembly (`FormatCatalogService.Initialize`)
+
+```mermaid
+flowchart TD
+    A[Initialize\nembeddedEntries, externalDir] --> B[Load embedded formats]
+    A --> C[Load external directory\n*.whfmt from disk]
+    A --> D[Load user AppData\n%APPDATA%\\WpfHexEditor\\FormatDefinitions]
+
+    B --> E{ImportFromJson\n+ IsValid?}
+    C --> E
+    D --> E
+
+    E -- OK --> F[Add to _formats\nList~FormatDefinition~]
+    E -- Fail --> G[Record FormatLoadFailure\nsource + reason]
+
+    F --> H[FormatDetectionService\nSetSharedCatalog\nstatic, locked]
+    H --> I[Fire CatalogReady event]
+    G --> J[Exposed via LoadFailures\nlogged to OutputPanel]
+```
+
+**Source priority:**
+
+| Priority | Source | Override behaviour |
+|---|---|---|
+| 1 | Embedded resources (DLL) | Base definitions |
+| 2 | External directory (parameter) | Can override embedded by name |
+| 3 | User AppData | Personal overrides (highest) |
+
+---
+
+## 4. Caching Map
+
+```mermaid
+graph LR
+    subgraph EmbeddedFormatCatalog[EmbeddedFormatCatalog — Singleton]
+        HC[(Header cache\nFrozenSet EmbeddedFormatEntry\nLazy, one-time)]
+        JC[(JSON cache\nDictionary string→string\nLazy per key, locked)]
+    end
+
+    subgraph FormatDetectionService
+        SC[(Shared catalog\nIReadOnlyList FormatDefinition\nStatic, set once at startup)]
+    end
+
+    HC -->|feeds| JC
+    JC -->|feeds| SC
+```
+
+| Cache | Type | Invalidation |
+|---|---|---|
+| Header entries | `FrozenSet<EmbeddedFormatEntry>` | Never — one-time lazy init |
+| JSON content | `Dictionary<string, string>` | Never — assembly immutable |
+| Shared catalog | `IReadOnlyList<FormatDefinition>` | Set once at `CatalogReady` |
+| Instance formats | `List<FormatDefinition>` per service | `ClearFormats()` |
+
+---
+
+## 5. Format Detection Flow
+
+Once the catalog is ready, detection runs each time a file is opened.
+
+```mermaid
+flowchart TD
+    A([File opened]) --> B[DetectFormat\nbyte array + fileName]
+    B --> C[ContentAnalyzer.Analyze\ntext vs binary, entropy]
+
+    C --> D[TIER 1 — Strong Signatures\nRequired=true, strength≥Medium]
+    D --> E{Confidence\n≥ 0.7?}
+    E -- Yes --> I
+    E -- No --> F[TIER 2 — Text Formats\nisTextFormat=true\npattern + extension match]
+    F --> G{Match\nfound?}
+    G -- Yes --> I
+    G -- No --> H[TIER 3 — Weak/Fallback\nRequired=false, strength≤Weak\nextension-heavy]
+    H --> I[ScoreAndRankCandidates]
+
+    I --> J[DecideFormat\nhighest score wins]
+    J --> K{Format\nfound?}
+    K -- Yes --> L[Open with preferredEditor\nor default HexEditor]
+    K -- No --> M[Fallback: HexEditor\nno format]
+```
+
+**Scoring weights:**
+
+| Signal | Weight |
+|---|---|
+| Signature confidence | 30 % |
+| Extension match | 30 % (40 % for shared signatures) |
+| ZIP-container content analysis | 25 % |
+| General content analysis | 20 % |
+
+---
+
+### 5.1 `TryDetectFormat` Inner Logic
+
+```mermaid
+sequenceDiagram
+    participant D as DetectFormat
+    participant F as FormatDefinition
+    participant I as FormatScriptInterpreter
+
+    D->>F: Check Detection.Required signature
+    alt Signature mismatch
+        F-->>D: return false (early exit)
+    end
+
+    D->>F: Check EntropyHint (weak signatures only)
+    alt Entropy out of range
+        F-->>D: return false
+    end
+
+    D->>I: new FormatScriptInterpreter(data, variables, byteProvider)
+    I->>I: ExecuteFunctions(format.Functions)
+    I->>I: ExecuteBlocks(format.Blocks)
+    I-->>D: List<CustomBackgroundBlock>, variables
+
+    opt v2.0 Checksums
+        D->>D: ChecksumEngine.Execute
+    end
+
+    opt v2.0 Assertions
+        D->>D: AssertionRunner.Run
+    end
+
+    D-->>D: return blocks.Count > 0
+```
+
+---
+
+## 6. Class Responsibility Map
+
+```mermaid
+classDiagram
+    class EmbeddedFormatCatalog {
+        <<Singleton>>
+        +GetAll() IReadOnlySet~EmbeddedFormatEntry~
+        +GetJson(key) string
+        +PreWarm() void
+        -MakeEntries() FrozenSet
+        -LoadHeader(key) EmbeddedFormatEntry?
+        -LoadGrammarHeader(key) EmbeddedFormatEntry?
+        -_jsonCache Dictionary
+    }
+
+    class EmbeddedFormatEntry {
+        <<record>>
+        +ResourceKey string
+        +Name string
+        +Category string
+        +Extensions IReadOnlyList~string~
+        +PreferredEditor string?
+        +IsTextFormat bool
+        +QualityScore double
+    }
+
+    class FormatCatalogService {
+        +Initialize(embedded, externalDir) Task
+        +LoadFailures IReadOnlyList~FormatLoadFailure~
+        +CatalogReady event
+        -_formats List~FormatDefinition~
+    }
+
+    class FormatDetectionService {
+        +ImportFromJson(json) FormatDefinition?
+        +DetectFormat(data, file, provider) FormatDetectionResult
+        +SetSharedCatalog(formats) void$
+        -s_sharedFormats IReadOnlyList$
+    }
+
+    class FormatDefinition {
+        +FormatName string
+        +Extensions string[]
+        +Detection DetectionRule
+        +Blocks List~BlockDefinition~
+        +Variables Dictionary
+        +IsValid() bool
+    }
+
+    class FormatScriptInterpreter {
+        +ExecuteBlocks(blocks) List~Block~
+        +ExecuteFunctions(functions) void
+        +Variables Dictionary
+    }
+
+    EmbeddedFormatCatalog "1" --> "*" EmbeddedFormatEntry : produces
+    FormatCatalogService --> EmbeddedFormatCatalog : reads headers + JSON
+    FormatCatalogService --> FormatDetectionService : calls ImportFromJson
+    FormatCatalogService --> FormatDetectionService : calls SetSharedCatalog
+    FormatDetectionService --> FormatDefinition : deserializes
+    FormatDetectionService --> FormatScriptInterpreter : instantiates per detection
+```
+
+---
+
+## 7. Error Handling
+
+| Stage | Error | Handling |
+|---|---|---|
+| `MakeEntries` | Parse exception on header | Entry skipped silently; next entry continues |
+| `ImportFromJson` | Invalid JSON / non-JSON content | Returns `null`; not treated as failure |
+| `ImportFromJson` | `IsValid()` = false | Returns `null` |
+| `FormatCatalogService.Initialize` | File I/O or parse exception | `FormatLoadFailure` recorded + logged |
+| `FormatCatalogService.Initialize` | `IsValid()` = false (external) | `FormatLoadFailure` recorded |
+| `DetectFormat` | No match | Returns `null`; hex editor fallback |
+| `DetectFormat` | Timeout (3 s) | Best candidate returned |
+
+**User-visible surfaces:**
+- **OutputPanel** — `OutputLogger.Error/Warn` for each `FormatLoadFailure`.
+- **Startup is never blocked** — failures are best-effort; the catalog loads whatever succeeds.
+
+---
+
+## 8. Full Call Chain Example — ZIP Format
+
+```
+MainWindow.InitializePluginSystemAsync()
+ └─ FormatCatalogService.Initialize(embeddedEntries, externalDir)
+     └─ EmbeddedFormatCatalog.Instance.GetAll()
+         └─ MakeEntries()
+             └─ Assembly.GetManifestResourceNames()
+                 → "WpfHexEditor.Definitions.FormatDefinitions.Archives.ZIP.whfmt"
+             └─ LoadHeader("...ZIP.whfmt")
+                 └─ JsonDocument.Parse (CommentHandling.Skip)
+                 └─ EmbeddedFormatEntry { Name="ZIP Archive", Extensions=[".zip",".jar",...], Category="Archives" }
+     └─ For each EmbeddedFormatEntry (whfmt only):
+         └─ EmbeddedFormatCatalog.GetJson(entry.ResourceKey)
+             └─ _jsonCache miss → OpenManifestResourceStream → ReadToEnd → cache
+         └─ FormatDetectionService.ImportFromJson(json)
+             └─ Skip /* comment header */
+             └─ JsonSerializer.Deserialize<FormatDefinition>()
+             └─ IsValid() → true
+             └─ Return FormatDefinition { FormatName="ZIP Archive", Blocks=[...] }
+         └─ _formats.Add(formatDefinition)
+     └─ FormatDetectionService.SetSharedCatalog(_formats)  ← static, locked
+     └─ Fire CatalogReady
+```
+
+---
+
+## 9. Key Files Reference
+
+| File | Path |
+|---|---|
+| `.csproj` (embedding) | `Core/WpfHexEditor.Core.Definitions/WpfHexEditor.Core.Definitions.csproj` |
+| `EmbeddedFormatCatalog.cs` | `Core/WpfHexEditor.Core.Definitions/EmbeddedFormatCatalog.cs` |
+| `IEmbeddedFormatCatalog.cs` | `Core/WpfHexEditor.Core.Definitions/IEmbeddedFormatCatalog.cs` |
+| `FormatDefinition.cs` | `Core/WpfHexEditor.Core/Models/FormatDefinition.cs` |
+| `FormatCatalogService.cs` | `Core/WpfHexEditor.Core/Services/FormatCatalogService.cs` |
+| `FormatDetectionService.cs` | `Core/WpfHexEditor.Core/Services/FormatDetectionService.cs` |
+| `FormatScriptInterpreter.cs` | `Core/WpfHexEditor.Core/Services/FormatScriptInterpreter.cs` |
+| `HexEditor.FormatDetection.cs` | `Editors/WpfHexEditor.HexEditor/PartialClasses/Features/` |
+| `MainWindow.PluginSystem.cs` | `WpfHexEditor.App/PartialClasses/MainWindow.PluginSystem.cs` |
+| `EmbeddedWhfmt_Tests.cs` | `Tests/` (build gate: 400+ formats) |


### PR DESCRIPTION
## Summary

- **StructureEditor**: wire `FormatSchemaValidator` (4-layer validation: JSON syntax, schema, rules, semantic)
- **TextEditor**: fix word-wrap viewport width — `Star`/`Auto` column switch + `InvalidateViewportSize` on `Loaded`/`SizeChanged`
- **ValidationError**: moved to shared `WpfHexEditor.Editor.Core` (single source of truth)
- **MarkdownPreviewPane**: minor fixes
- **27 new whfmt formats**: Archives (ANDROID_BACKUP, CPIO, WARC), Certificates (SNK), Data (WHFMT), Database (LEVELDB_SST), Disk (APFS, QCOW2, SQUASHFS, VHDX), Game (ROM_3DS, ROM_GBC, ROM_NDS), MachineLearning (ONNX, PYTORCH, SAFETENSORS, TFLITE), Programming (DIAGSESSION, DOTNET_RESOURCES, NETTRACE, PORTABLE_PDB, WAT), Subtitles (ASS, SRT, SUP, VTT), System (ETL)
- **Docs**: WHFMT_LOADING_PIPELINE pipeline reference added

## Test plan

- [ ] Open a `.whfmt` file in StructureEditor — validation errors should appear in the summary panel
- [ ] Toggle word-wrap in TextEditor — no horizontal scroll glitch, viewport resizes correctly
- [ ] Verify new whfmt formats are detected on matching binary files
- [ ] No regression on existing editors (CodeEditor, MarkdownEditor)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)